### PR TITLE
fix: updated docs about isolated declarations, moved sourcemapsPlugin…

### DIFF
--- a/examples/isolated-declarations-oxc/package.json
+++ b/examples/isolated-declarations-oxc/package.json
@@ -19,9 +19,9 @@
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
     "typesVersions": {
-        "*": {
+        ">=5.5": {
             ".": [
-                "./dist/index.d.ts"
+                "./dist/index.d.cts"
             ]
         }
     },

--- a/examples/isolated-declarations-oxc/package.json
+++ b/examples/isolated-declarations-oxc/package.json
@@ -21,7 +21,7 @@
     "typesVersions": {
         ">=5.5": {
             ".": [
-                "./dist/index.d.cts"
+                "./dist/index.d.ts"
             ]
         }
     },

--- a/examples/isolated-declarations-oxc/packem.config.ts
+++ b/examples/isolated-declarations-oxc/packem.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     isolatedDeclarationTransformer,
     rollup: {
         node10Compatibility: {
+            typeScriptVersion: ">=5.5",
             writeToPackageJson: true,
         },
     },

--- a/examples/isolated-declarations-swc/package.json
+++ b/examples/isolated-declarations-swc/package.json
@@ -19,9 +19,9 @@
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
     "typesVersions": {
-        "*": {
+        ">=5.5": {
             ".": [
-                "./dist/index.d.ts"
+                "./dist/index.d.cts"
             ]
         }
     },

--- a/examples/isolated-declarations-swc/package.json
+++ b/examples/isolated-declarations-swc/package.json
@@ -21,7 +21,7 @@
     "typesVersions": {
         ">=5.5": {
             ".": [
-                "./dist/index.d.cts"
+                "./dist/index.d.ts"
             ]
         }
     },

--- a/examples/isolated-declarations-swc/packem.config.ts
+++ b/examples/isolated-declarations-swc/packem.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     isolatedDeclarationTransformer,
     rollup: {
         node10Compatibility: {
+            typeScriptVersion: ">=5.5",
             writeToPackageJson: true,
         },
     },

--- a/examples/isolated-declarations-typescript/package.json
+++ b/examples/isolated-declarations-typescript/package.json
@@ -19,14 +19,9 @@
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
     "typesVersions": {
-        ">=5.0": {
+        ">=5.5": {
             ".": [
                 "./dist/index.d.cts"
-            ]
-        },
-        "*": {
-            ".": [
-                "./dist/index.d.ts"
             ]
         }
     },

--- a/examples/isolated-declarations-typescript/package.json
+++ b/examples/isolated-declarations-typescript/package.json
@@ -21,7 +21,7 @@
     "typesVersions": {
         ">=5.5": {
             ".": [
-                "./dist/index.d.cts"
+                "./dist/index.d.ts"
             ]
         }
     },

--- a/examples/isolated-declarations-typescript/packem.config.ts
+++ b/examples/isolated-declarations-typescript/packem.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     isolatedDeclarationTransformer,
     rollup: {
         node10Compatibility: {
+            typeScriptVersion: ">=5.5",
             writeToPackageJson: true,
         },
     },

--- a/packages/packem/README.md
+++ b/packages/packem/README.md
@@ -53,7 +53,7 @@ It uses the `exports` configuration in `package.json` and recognizes entry file 
 -   ✅ Supports dynamic import
 -   ✅ Supports `tsconfig.json` paths and `package.json` imports resolution
 -   ✅ ESM ⇄ CJS interoperability
--   ✅ Supports isolated declaration types (experimental)
+-   ✅ Supports isolated declaration types (experimental) (Typescript version 5.5 or higher)
 -   ✅ Supports wasm [WebAssembly modules](http://webassembly.org)
 -   ✅ Supports css, [sass](https://github.com/sass/sass), [less](https://github.com/less/less.js), [stylus](https://github.com/stylus/stylus) and Up-to-date [CSS Modules](https://github.com/css-modules/css-modules) (experimental)
 -   ✅ [TypeDoc](https://github.com/TypeStrong/TypeDoc) documentation generation
@@ -541,6 +541,30 @@ export default defineConfig({
 });
 ```
 
+### Isolated declaration types (in TypeScript 5.5)
+
+> Generating .d.ts files with the default `rollup-plugin-dts` is slow because the TypeScript compiler must perform costly type inference, but these files streamline type checking by removing unnecessary details, and while shipping raw TypeScript files could simplify workflows, it is impractical due to ecosystem assumptions and performance trade-offs, which isolated declarations aim to address.
+
+You need to choose of the supported transformer to use isolated declaration types.
+
+-   [oxc](https://github.com/oxc-project/oxc)
+-   [@swc/core](https://github.com/swc-project/swc)
+-   [typescript](https://github.com/microsoft/TypeScript)
+
+Default is `typescript`.
+
+```ts
+import { defineConfig } from "@visulima/packem/config";
+import transformer from "@visulima/packem/transformer/esbuild";
+import isolatedDeclarationTransformer from "@visulima/packem/dts/isolated/transformer/typescript";
+
+// eslint-disable-next-line import/no-unused-modules
+export default defineConfig({
+    transformer,
+    isolatedDeclarationTransformer,
+});
+```
+
 <!-- Modified copy of https://github.com/Anidetrix/rollup-plugin-styles/blob/main/README.md -->
 
 ## Css and Css Modules
@@ -802,20 +826,6 @@ You can feed the output file to analysis tools like [bundle buddy](https://www.b
 
 The file outputs as metafile-{bundleName}-{format}.json, e.g. `packem` will generate metafile-test-cjs.json and metafile-test-es.json.
 
-## Configuration
-
-### packem.config.js
-
-The packem configuration file is a JavaScript file that exports an object with the following properties:
-
-#### transformer
-
-You choose which one of the three supported transformer to use.
-
--   [esbuild](https://github.com/evanw/esbuild)
--   [@swc/core](https://github.com/swc-project/swc)
--   [sucrase](https://github.com/alangpierce/sucrase)
-
 ### onSuccess
 
 You can specify command to be executed after a successful build, specially useful for **Watch mode**
@@ -856,6 +866,20 @@ export default defineConfig({
     },
 });
 ```
+
+## Configuration
+
+### packem.config.js
+
+The packem configuration file is a JavaScript file that exports an object with the following properties:
+
+#### transformer
+
+You choose which one of the three supported transformer to use.
+
+-   [esbuild](https://github.com/evanw/esbuild)
+-   [@swc/core](https://github.com/swc-project/swc)
+-   [sucrase](https://github.com/alangpierce/sucrase)
 
 ## Related
 

--- a/packages/packem/__tests__/intigration/url.test.ts
+++ b/packages/packem/__tests__/intigration/url.test.ts
@@ -278,7 +278,7 @@ module.exports = png;
             [
                 join(temporaryDirectoryPath, "/dist/png.cjs"),
                 join(temporaryDirectoryPath, "/dist/png.mjs"),
-                join(temporaryDirectoryPath, "/dist/", temporaryDirectoryPath.replace("/tmp/", ""), "/src/6b71fbe07b498a82.png"),
+                join(temporaryDirectoryPath, "/dist/", temporaryDirectoryPath.split("/").pop() as string, "/src/6b71fbe07b498a82.png"),
             ],
             false,
         );

--- a/packages/packem/__tests__/intigration/url.test.ts
+++ b/packages/packem/__tests__/intigration/url.test.ts
@@ -3,7 +3,7 @@ import { cpSync } from "node:fs";
 import { readdir, rm } from "node:fs/promises";
 
 import { ensureDir, isAccessibleSync, readFileSync, writeFile, writeJson } from "@visulima/fs";
-import { join, resolve } from "@visulima/path";
+import { basename, join, resolve } from "@visulima/path";
 import { temporaryDirectory } from "tempy";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -267,7 +267,7 @@ module.exports = png;
 
         const type = "png";
 
-        const pngPath = join(temporaryDirectoryPath.split("/").pop() as string, "/src/6b71fbe07b498a82.png");
+        const pngPath = join(basename(temporaryDirectoryPath), "/src/6b71fbe07b498a82.png");
 
         await build(
             type,

--- a/packages/packem/__tests__/intigration/url.test.ts
+++ b/packages/packem/__tests__/intigration/url.test.ts
@@ -267,6 +267,8 @@ module.exports = png;
 
         const type = "png";
 
+        const pngPath = join(temporaryDirectoryPath.split("/").pop() as string, "/src/6b71fbe07b498a82.png");
+
         await build(
             type,
             {
@@ -278,14 +280,14 @@ module.exports = png;
             [
                 join(temporaryDirectoryPath, "/dist/png.cjs"),
                 join(temporaryDirectoryPath, "/dist/png.mjs"),
-                join(temporaryDirectoryPath, "/dist/", temporaryDirectoryPath.split("/").pop() as string, "/src/6b71fbe07b498a82.png"),
+                join(temporaryDirectoryPath, "/dist/", pngPath),
             ],
             false,
         );
 
         const mjsContent = readFileSync(join(temporaryDirectoryPath, "dist", type + ".mjs"));
 
-        expect(mjsContent).toBe(`const png = "${temporaryDirectoryPath.replace("/tmp/", "")}/src/6b71fbe07b498a82.png";
+        expect(mjsContent).toBe(`const png = "${pngPath}";
 
 export { png as default };
 `);
@@ -294,7 +296,7 @@ export { png as default };
 
         expect(cjsContent).toBe(`'use strict';
 
-const png = "${temporaryDirectoryPath.replace("/tmp/", "")}/src/6b71fbe07b498a82.png";
+const png = "${pngPath}";
 
 module.exports = png;
 `);

--- a/packages/packem/package.json
+++ b/packages/packem/package.json
@@ -311,6 +311,62 @@
             "css/minifier/lightningcss": [
                 "./dist/rollup/plugins/css/minifiers/lightningcss.d.ts"
             ]
+        },
+        ">=5.5": {
+            ".": [
+                "./dist/packem.d.ts"
+            ],
+            "config": [
+                "./dist/config.d.ts"
+            ],
+            "transformer/esbuild": [
+                "./dist/rollup/plugins/esbuild/index.d.ts"
+            ],
+            "transformer/swc": [
+                "./dist/rollup/plugins/swc/swc-plugin.d.ts"
+            ],
+            "dts/isolated/transformer/swc": [
+                "./dist/rollup/plugins/swc/isolated-declarations-swc-transformer.d.ts"
+            ],
+            "dts/isolated/transformer/oxc": [
+                "./dist/rollup/plugins/oxc/isolated-declarations-oxc-transformer.d.ts"
+            ],
+            "dts/isolated/transformer/typescript": [
+                "./dist/rollup/plugins/typescript/isolated-declarations-typescript-transformer.d.ts"
+            ],
+            "transformer/sucrase": [
+                "./dist/rollup/plugins/sucrase/index.d.ts"
+            ],
+            "builder/typedoc": [
+                "./dist/builder/typedoc/index.d.ts"
+            ],
+            "runtime/inject-css": [
+                "./dist/rollup/plugins/css/runtime/inject-css.d.ts"
+            ],
+            "css/loader/sourcemap": [
+                "./dist/rollup/plugins/css/loaders/sourcemap.d.ts"
+            ],
+            "css/loader/less": [
+                "./dist/rollup/plugins/css/loaders/less/index.d.ts"
+            ],
+            "css/loader/postcss": [
+                "./dist/rollup/plugins/css/loaders/postcss/index.d.ts"
+            ],
+            "css/loader/sass": [
+                "./dist/rollup/plugins/css/loaders/sass/index.d.ts"
+            ],
+            "css/loader/stylus": [
+                "./dist/rollup/plugins/css/loaders/stylus/index.d.ts"
+            ],
+            "css/loader/lightningcss": [
+                "./dist/rollup/plugins/css/loaders/lightningcss.d.ts"
+            ],
+            "css/minifier/cssnano": [
+                "./dist/rollup/plugins/css/minifiers/cssnano.d.ts"
+            ],
+            "css/minifier/lightningcss": [
+                "./dist/rollup/plugins/css/minifiers/lightningcss.d.ts"
+            ]
         }
     },
     "bin": {

--- a/packages/packem/package.json
+++ b/packages/packem/package.json
@@ -545,10 +545,10 @@
         "sass-embedded": ">=1.79.4",
         "stylus": ">=0.63.0",
         "sucrase": ">=3.35.0",
-        "typedoc": "0.26.10",
-        "typedoc-plugin-markdown": "4.2.9",
-        "typedoc-plugin-rename-defaults": "0.7.1",
-        "typescript": "^4.5 || ^5.0"
+        "typedoc": ">=0.26.0",
+        "typedoc-plugin-markdown": ">=4.2.0",
+        "typedoc-plugin-rename-defaults": ">=0.7.0",
+        "typescript": ">=4.5 || >=5.0"
     },
     "peerDependenciesMeta": {
         "@ckeditor/typedoc-plugins": {

--- a/packages/packem/packem.config.ts
+++ b/packages/packem/packem.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
             path: "./LICENSE.md",
         },
         node10Compatibility: {
-            typeScriptVersion: ">=5.0",
+            typeScriptVersion: ">=5.5",
             writeToPackageJson: true,
         },
     },

--- a/packages/packem/packem.config.ts
+++ b/packages/packem/packem.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "./src/config";
 import transformer from "./src/rollup/plugins/esbuild";
+import isolatedDeclarationTransformer from "./src/rollup/plugins/typescript/isolated-declarations-typescript-transformer";
 
 // eslint-disable-next-line import/no-unused-modules
 export default defineConfig({
     cjsInterop: true,
     externals: ["stylus", "less", "sass", "node-sass", "postcss", "lightningcss"],
     fileCache: true,
+    isolatedDeclarationTransformer,
     rollup: {
         license: {
             path: "./LICENSE.md",

--- a/packages/packem/src/commands/add.ts
+++ b/packages/packem/src/commands/add.ts
@@ -84,6 +84,7 @@ const createAddCommand = (cli: Cli): void => {
                     return;
                 }
 
+                // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
                 const cssLoaders: (keyof typeof cssLoaderDependencies | "sourceMap")[] = [];
 
                 const mainCssLoader = (await select({
@@ -128,7 +129,7 @@ const createAddCommand = (cli: Cli): void => {
                 const packagesToInstall: string[] = [];
 
                 for (const loader of cssLoaders) {
-                    packagesToInstall.push(...cssLoaderDependencies[loader as keyof typeof cssLoaderDependencies]);
+                    packagesToInstall.push(...cssLoaderDependencies[loader as keyof typeof cssLoaderDependencies] as string[]);
                 }
 
                 cssLoaders.push("sourceMap");

--- a/packages/packem/src/commands/init.ts
+++ b/packages/packem/src/commands/init.ts
@@ -247,7 +247,7 @@ const createInitCommand = (cli: Cli): void => {
 
                 if (shouldInstall) {
                     for (const loader of cssLoaders) {
-                        packagesToInstall.push(...cssLoaderDependencies[loader as keyof typeof cssLoaderDependencies]);
+                        packagesToInstall.push(...cssLoaderDependencies[loader as keyof typeof cssLoaderDependencies] as string[]);
                     }
                 }
 

--- a/packages/packem/src/commands/utils/css-loader-dependencies.ts
+++ b/packages/packem/src/commands/utils/css-loader-dependencies.ts
@@ -1,4 +1,4 @@
-const cssLoaderDependencies = {
+const cssLoaderDependencies: Record<string, string[]> = {
     less: ["less"],
     lightningcss: ["lightningcss"],
     "node-sass": ["node-sass"],

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -783,8 +783,6 @@ export const getRollupDtsOptions = async (context: BuildContext, fileCache: File
 
             nodeResolver,
 
-            context.options.sourcemap && sourcemapsPlugin(context.options.rollup.sourcemap),
-
             ...normalPlugins,
 
             await memoizeDtsPluginByKey(uniqueProcessId)(context),

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -45,6 +45,7 @@ import { rawPlugin } from "./plugins/raw";
 import resolveFileUrlPlugin from "./plugins/resolve-file-url";
 import type { ShebangOptions } from "./plugins/shebang";
 import { removeShebangPlugin, shebangPlugin } from "./plugins/shebang";
+import { sourcemapsPlugin } from "./plugins/source-maps";
 import type { SucrasePluginConfig } from "./plugins/sucrase/types";
 import type { SwcPluginConfig } from "./plugins/swc/types";
 import { patchTypescriptTypes as patchTypescriptTypesPlugin } from "./plugins/typescript/patch-typescript-types";
@@ -56,7 +57,6 @@ import createSplitChunks from "./utils/chunks/create-split-chunks";
 import getChunkFilename from "./utils/get-chunk-filename";
 import getEntryFileNames from "./utils/get-entry-file-names";
 import resolveAliases from "./utils/resolve-aliases";
-import { sourcemapsPlugin } from "./plugins/source-maps";
 
 const sortUserPlugins = (plugins: RollupPlugins | undefined, type: "build" | "dts"): [Plugin[], Plugin[], Plugin[]] => {
     const prePlugins: Plugin[] = [];
@@ -454,8 +454,6 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
         ].filter(Boolean),
 
         plugins: [
-            context.options.sourcemap && sourcemapsPlugin(context.options.rollup.sourcemap),
-
             cachingPlugin(resolveFileUrlPlugin(), fileCache),
             cachingPlugin(resolveTypescriptMjsCtsPlugin(), fileCache),
 
@@ -495,18 +493,6 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
 
             context.options.rollup.wasm && wasmPlugin(context.options.rollup.wasm),
 
-            // @TODO check if this can be moved into the dts build
-            context.options.declaration &&
-                context.options.rollup.isolatedDeclarations &&
-                context.options.isolatedDeclarationTransformer &&
-                isolatedDeclarationsPlugin(
-                    join(context.options.rootDir, context.options.sourceDir),
-                    context.options.isolatedDeclarationTransformer,
-                    context.options.declaration,
-                    Boolean(context.options.rollup.cjsInterop),
-                    context.options.rollup.isolatedDeclarations,
-                ),
-
             context.options.rollup.url && urlPlugin(context.options.rollup.url),
 
             context.options.rollup.css &&
@@ -537,7 +523,20 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
 
             context.options.rollup.raw && cachingPlugin(rawPlugin(context.options.rollup.raw), fileCache),
 
+            context.options.sourcemap && sourcemapsPlugin(context.options.rollup.sourcemap),
+
             ...normalPlugins,
+
+            context.options.declaration &&
+                context.options.rollup.isolatedDeclarations &&
+                context.options.isolatedDeclarationTransformer &&
+                isolatedDeclarationsPlugin(
+                    join(context.options.rootDir, context.options.sourceDir),
+                    context.options.isolatedDeclarationTransformer,
+                    context.options.declaration,
+                    Boolean(context.options.rollup.cjsInterop),
+                    context.options.rollup.isolatedDeclarations,
+                ),
 
             context.options.transformer(getTransformerConfig(context.options.transformerName, context)),
 
@@ -744,8 +743,6 @@ export const getRollupDtsOptions = async (context: BuildContext, fileCache: File
         ].filter(Boolean),
 
         plugins: [
-            context.options.sourcemap && sourcemapsPlugin(context.options.rollup.sourcemap),
-
             cachingPlugin(resolveFileUrlPlugin(), fileCache),
             cachingPlugin(resolveTypescriptMjsCtsPlugin(), fileCache),
 
@@ -785,6 +782,8 @@ export const getRollupDtsOptions = async (context: BuildContext, fileCache: File
             ...prePlugins,
 
             nodeResolver,
+
+            context.options.sourcemap && sourcemapsPlugin(context.options.rollup.sourcemap),
 
             ...normalPlugins,
 


### PR DESCRIPTION
… to a different position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added documentation on "Isolated declaration types" for TypeScript 5.5 and above, highlighting performance benefits and configuration details.
	- Updated the configuration to include support for the isolated declaration transformer in the Rollup build process.
	- Enhanced functionality for adding CSS loaders, including user prompts and improved handling of Sass loaders and CSS minifiers.

- **Bug Fixes**
	- Enhanced type safety for `cssLoaderDependencies`, clarifying its structure.

- **Documentation**
	- Improved readability and organization of the README.md, including minor formatting adjustments.
	- Updated `package.json` files across examples to specify TypeScript version compatibility.

- **Chores**
	- Streamlined management of Rollup plugins and source map generation for better configuration flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->