### PR TITLE
feat: experimental oxc resolver plugin to replace rollup node-resolve…

### DIFF
--- a/packages/packem/packem.config.ts
+++ b/packages/packem/packem.config.ts
@@ -5,6 +5,9 @@ import isolatedDeclarationTransformer from "./src/rollup/plugins/typescript/isol
 // eslint-disable-next-line import/no-unused-modules
 export default defineConfig({
     cjsInterop: true,
+    experimental: {
+        oxcResolve: true,
+    },
     fileCache: true,
     isolatedDeclarationTransformer,
     rollup: {

--- a/packages/packem/src/packem.ts
+++ b/packages/packem/src/packem.ts
@@ -187,6 +187,11 @@ const generateOptions = (
                 // Optionally preserve symbol names during minification
                 tsconfigRaw: tsconfig?.config,
             },
+            experimental: {
+                resolve: {
+                    extensions: DEFAULT_EXTENSIONS,
+                },
+            },
             // https://github.com/microsoft/TypeScript/issues/58944
             isolatedDeclarations: {
                 exclude: EXCLUDE_REGEXP,

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -52,6 +52,7 @@ import createSplitChunks from "./utils/chunks/create-split-chunks";
 import getChunkFilename from "./utils/get-chunk-filename";
 import getEntryFileNames from "./utils/get-entry-file-names";
 import resolveAliases from "./utils/resolve-aliases";
+import { oxcResolvePlugin } from "./plugins/oxc/oxc-resolve";
 
 const sortUserPlugins = (plugins: RollupPlugins | undefined, type: "build" | "dts"): [Plugin[], Plugin[], Plugin[]] => {
     const prePlugins: Plugin[] = [];
@@ -400,7 +401,10 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
 
             ...prePlugins,
 
-            nodeResolver,
+            oxcResolvePlugin({
+                extensions: context.options.rollup.resolve.extensions,
+            }, context.options.rootDir, context.tsconfig?.path),
+            // nodeResolver,
 
             context.options.rollup.polyfillNode &&
                 polyfillPlugin({

--- a/packages/packem/src/rollup/plugins/oxc/oxc-resolve.ts
+++ b/packages/packem/src/rollup/plugins/oxc/oxc-resolve.ts
@@ -1,0 +1,116 @@
+import { createFilter } from "@rollup/pluginutils";
+import type { NormalizedPackageJson } from "@visulima/package";
+import { findPackageJson } from "@visulima/package/package-json";
+import { dirname } from "@visulima/path";
+import type { NapiResolveOptions } from "oxc-resolver";
+import { ResolverFactory } from "oxc-resolver";
+import type { Plugin } from "rollup";
+
+export type OxcResolveOptions = { ignoreSideEffectsForRoot?: boolean } & Omit<NapiResolveOptions, "tsconfig">;
+
+const packageJsonCache = new Map<string, NormalizedPackageJson>();
+
+export const oxcResolvePlugin = (options: OxcResolveOptions, rootDirectory: string, tsconfigPath?: string) => {
+    const { ignoreSideEffectsForRoot, ...userOptions } = options;
+
+    const resolver = new ResolverFactory({
+        ...userOptions,
+        roots: [...(userOptions.roots ?? []), rootDirectory],
+        tsconfig: tsconfigPath ? { configFile: tsconfigPath } : undefined,
+    });
+
+    return <Plugin>{
+        name: "oxc-resolve",
+        resolveId: {
+            async handler(source, importer, { isEntry }) {
+                const resolveDirectory = isEntry || !importer ? dirname(source) : dirname(importer);
+
+                const { error, path: id } = resolver.sync(resolveDirectory, source);
+
+                if (error) {
+                    // console.debug(error, {
+                    //     context: [
+                    //         {
+                    //             basedir,
+                    //             caller: userOptions.caller,
+                    //             extensions: userOptions.extensions,
+                    //             id,
+                    //         },
+                    //     ],
+                    // });
+                    return null;
+                }
+
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                let hasModuleSideEffects: (location: string) => boolean = (_: string) => false;
+
+                try {
+                    const { packageJson, path } = await findPackageJson(dirname(id as string), {
+                        // @ts-expect-error - missing the correct type export
+                        cache: packageJsonCache,
+                    });
+
+                    const packageRoot = dirname(path);
+
+                    if (!ignoreSideEffectsForRoot || rootDirectory !== packageRoot) {
+                        const packageSideEffects = packageJson.sideEffects;
+
+                        if (typeof packageSideEffects === "boolean") {
+                            hasModuleSideEffects = () => packageSideEffects;
+                        } else if (Array.isArray(packageSideEffects)) {
+                            const finalPackageSideEffects = packageSideEffects.map((sideEffect) => {
+                                /*
+                                 * The array accepts simple glob patterns to the relevant files... Patterns like .css, which do not include a /, will be treated like **\/.css.
+                                 * https://webpack.js.org/guides/tree-shaking/
+                                 */
+                                if (sideEffect.includes("/")) {
+                                    return sideEffect;
+                                }
+                                return `**/${sideEffect}`;
+                            });
+
+                            hasModuleSideEffects = createFilter(finalPackageSideEffects, null, {
+                                resolve: packageRoot,
+                            });
+                        }
+                    }
+                } catch (error: any) {
+                    // eslint-disable-next-line no-console
+                    console.debug(error.message, {
+                        context: [
+                            {
+                                basedir: resolveDirectory,
+                                caller: "Resolver",
+                                error,
+                                extensions: userOptions.extensions,
+                                id,
+                            },
+                        ],
+                    });
+                }
+
+                const rollupResolvedResult = await this.resolve(id as string, importer, {
+                    // ...options,
+                    skipSelf: true,
+                });
+
+                if (rollupResolvedResult) {
+                    // Handle plugins that manually make the result external and the external option
+                    if (rollupResolvedResult.external) {
+                        return false;
+                    }
+
+                    // Allow other plugins to take over resolution
+                    if (rollupResolvedResult.id !== id) {
+                        return rollupResolvedResult;
+                    }
+
+                    return { id, meta: rollupResolvedResult.meta, moduleSideEffects: hasModuleSideEffects(id) };
+                }
+
+                return null;
+            },
+            order: "post",
+        },
+    };
+};

--- a/packages/packem/src/rollup/plugins/oxc/oxc-resolve.ts
+++ b/packages/packem/src/rollup/plugins/oxc/oxc-resolve.ts
@@ -25,7 +25,7 @@ export const oxcResolvePlugin = (options: OxcResolveOptions, rootDirectory: stri
             async handler(source, importer, { isEntry }) {
                 const resolveDirectory = isEntry || !importer ? dirname(source) : dirname(importer);
 
-                const { error, path: id } = resolver.sync(resolveDirectory, source);
+                const { error, path: id } = await resolver.async(resolveDirectory, source);
 
                 if (error) {
                     // console.debug(error, {

--- a/packages/packem/src/types.ts
+++ b/packages/packem/src/types.ts
@@ -35,6 +35,7 @@ import type { UrlOptions } from "./rollup/plugins/url";
 import type { SourcemapsPluginOptions } from "./rollup/plugins/source-maps";
 import type { ResolveExternalsPluginOptions } from "./rollup/plugins/resolve-externals-plugin";
 import type { TsconfigPathsPluginOptions } from "./rollup/plugins/typescript/resolve-tsconfig-paths-plugin";
+import type { OxcResolveOptions } from "./rollup/plugins/oxc/oxc-resolve";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 
@@ -116,6 +117,9 @@ export interface RollupBuildOptions {
     watch?: RollupOptions["watch"];
     sourcemap?: SourcemapsPluginOptions;
     resolveExternals?: ResolveExternalsPluginOptions;
+    experimental?: {
+        resolve?: OxcResolveOptions | false;
+    }
 }
 
 export type TypeDocumentOptions = {
@@ -166,6 +170,12 @@ export interface BuildOptions {
     cjsInterop?: boolean;
     clean: boolean;
     debug: boolean;
+    experimental?: {
+        /**
+         * If `true`, the `oxc resolve` plugin will be used instead of the default `@rollup/plugin-node-resolve` and `@rollup/plugin-alias`.
+         */
+        oxcResolve?: boolean;
+    };
     /**
      * `compatible` means "src/gather.ts" will generate "dist/index.d.mts", "dist/index.d.cts" and "dist/index.d.ts".
      * `node16` means "src/gather.ts" will generate "dist/index.d.mts" and "dist/index.d.cts".


### PR DESCRIPTION
… and alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `oxcResolvePlugin` for enhanced module resolution in the Rollup build process.
	- Added experimental configuration options for the `oxcResolve` feature.
	- Expanded build options to include experimental properties for module resolution.

- **Bug Fixes**
	- Improved error handling in module identifier resolution.

- **Documentation**
	- Updated type definitions to reflect new options and interfaces related to the `oxcResolvePlugin`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->