### PR TITLE
feat: adding outputExtensionMap to overwrite output extensions

### DIFF
--- a/packages/packem/__tests__/intigration/__snapshots__/package-json-exports.test.ts.snap
+++ b/packages/packem/__tests__/intigration/__snapshots__/package-json-exports.test.ts.snap
@@ -45,6 +45,31 @@ exports.cli = cli;
 "
 `;
 
+exports[`packem package.json exports > should generate proper assets with custom extensions from outputExtensionMap > cjs output 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+
+const value = "index";
+
+exports.value = value;
+"
+`;
+
+exports[`packem package.json exports > should generate proper assets with custom extensions from outputExtensionMap > dts output 1`] = `
+"declare const value = "index";
+
+export { value };
+"
+`;
+
+exports[`packem package.json exports > should generate proper assets with custom extensions from outputExtensionMap > mjs output 1`] = `
+"const value = "index";
+
+export { value };
+"
+`;
+
 exports[`packem package.json exports > should generate proper assets with js based on the package.json exports default > cjs output 1`] = `
 "'use strict';
 

--- a/packages/packem/__tests__/intigration/typescript.test.ts
+++ b/packages/packem/__tests__/intigration/typescript.test.ts
@@ -1247,6 +1247,8 @@ declare const index = "index";
 
 export { AppContext, index };
 `);
+    }, {
+        retry: 3
     });
 
     describe("isolated declarations", () => {

--- a/packages/packem/eslint.config.js
+++ b/packages/packem/eslint.config.js
@@ -1,7 +1,8 @@
 import { createConfig } from "@anolilab/eslint-config";
 
 export default createConfig({
-    ignores: ["**/__fixtures__"],
+    css: false,
+    ignores: ["dist", "node_modules", "coverage", "__fixtures__", "__docs__", "examples", "vitest.config.ts", "packem.config.ts", ".secretlintrc.cjs", "tsconfig.eslint.json", "README.md"],
     jsx: false,
     react: false,
     // Enable this after the lint errors are fixed.

--- a/packages/packem/src/jit/create-stub.ts
+++ b/packages/packem/src/jit/create-stub.ts
@@ -94,7 +94,7 @@ const createStub = async (context: BuildContext): Promise<void> => {
             const typePath = `${resolvedEntryWithoutExtension}.d.mts`;
 
             writeFileSync(
-                `${output}.mjs`,
+                `${output}.${context.options.outputExtensionMap?.esm ?? "mjs"}`,
                 shebang
                 + [
                     `import { createJiti } from "${jitiESMPath}";`,
@@ -134,7 +134,7 @@ const createStub = async (context: BuildContext): Promise<void> => {
             const typePath = `${resolvedEntryWithoutExtension}.d.cts`;
 
             writeFileSync(
-                `${output}.cjs`,
+                `${output}.${context.options.outputExtensionMap?.cjs ?? "cjs"}`,
                 shebang
                 + [
                     `const { createJiti } = require("${jitiCJSPath}");`,
@@ -160,9 +160,9 @@ const createStub = async (context: BuildContext): Promise<void> => {
 
         if (shebang) {
             // eslint-disable-next-line no-await-in-loop
-            await makeExecutable(`${output}.cjs`);
+            await makeExecutable(`${output}.${context.options.outputExtensionMap?.cjs ?? "cjs"}`);
             // eslint-disable-next-line no-await-in-loop
-            await makeExecutable(`${output}.mjs`);
+            await makeExecutable(`${output}.${context.options.outputExtensionMap?.esm ?? "mjs"}`);
         }
     }
 

--- a/packages/packem/src/packem/index.ts
+++ b/packages/packem/src/packem/index.ts
@@ -583,6 +583,19 @@ const generateOptions = (
         validateAliasEntries(options.rollup.alias.entries);
     }
 
+    // Validate outputExtensionMap if it contains invalid extensions
+    if (options.outputExtensionMap) {
+        for (const [key, value] of Object.entries(options.outputExtensionMap)) {
+            if (!["cjs", "esm"].includes(key)) {
+                throw new Error(`Invalid output extension map: ${key} must be "cjs" or "esm"`);
+            }
+
+            if (typeof value !== "string") {
+                throw new TypeError(`Invalid output extension map: ${key} must be a string`);
+            }
+        }
+    }
+
     return options;
 };
 

--- a/packages/packem/src/packem/index.ts
+++ b/packages/packem/src/packem/index.ts
@@ -593,6 +593,10 @@ const generateOptions = (
             if (typeof value !== "string") {
                 throw new TypeError(`Invalid output extension map: ${key} must be a string`);
             }
+
+            if (value.startsWith(".")) {
+                throw new Error(`Invalid output extension map: ${key} must not start with a dot. Example: "cjs": "c.js", "esm": "m.js"`);
+            }
         }
     }
 

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -337,10 +337,10 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
                 // but make sure to adjust `hash`, `assetDir` and `publicPath`
                 // options for url handler accordingly.
                 assetFileNames: "[name]-[hash][extname]",
-                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, "cjs"),
+                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, context.options.outputExtensionMap?.cjs.js ?? "cjs"),
                 compact: context.options.minify,
                 dir: resolve(context.options.rootDir, context.options.outDir),
-                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, "cjs"),
+                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, context.options.outputExtensionMap?.cjs.js ?? "cjs"),
                 esModule: useEsModuleMark ?? "if-default-prop",
                 exports: "auto",
                 // turn off live bindings support (exports.* getters for re-exports)
@@ -371,10 +371,10 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
                 // but make sure to adjust `hash`, `assetDir` and `publicPath`
                 // options for url handler accordingly.
                 assetFileNames: "[name]-[hash][extname]",
-                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, "mjs"),
+                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, context.options.outputExtensionMap?.esm.js ?? "mjs"),
                 compact: context.options.minify,
                 dir: resolve(context.options.rootDir, context.options.outDir),
-                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, "mjs"),
+                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, context.options.outputExtensionMap?.esm.js ?? "mjs"),
                 esModule: useEsModuleMark ?? "if-default-prop",
                 exports: "auto",
                 // turn off live bindings support (exports.* getters for re-exports)

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -337,10 +337,10 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
                 // but make sure to adjust `hash`, `assetDir` and `publicPath`
                 // options for url handler accordingly.
                 assetFileNames: "[name]-[hash][extname]",
-                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, context.options.outputExtensionMap?.cjs.js ?? "cjs"),
+                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, context.options.outputExtensionMap?.cjs ?? "cjs"),
                 compact: context.options.minify,
                 dir: resolve(context.options.rootDir, context.options.outDir),
-                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, context.options.outputExtensionMap?.cjs.js ?? "cjs"),
+                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, context.options.outputExtensionMap?.cjs ?? "cjs"),
                 esModule: useEsModuleMark ?? "if-default-prop",
                 exports: "auto",
                 // turn off live bindings support (exports.* getters for re-exports)
@@ -371,10 +371,10 @@ export const getRollupOptions = async (context: BuildContext, fileCache: FileCac
                 // but make sure to adjust `hash`, `assetDir` and `publicPath`
                 // options for url handler accordingly.
                 assetFileNames: "[name]-[hash][extname]",
-                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, context.options.outputExtensionMap?.esm.js ?? "mjs"),
+                chunkFileNames: (chunk: PreRenderedChunk) => getChunkFilename(chunk, context.options.outputExtensionMap?.esm ?? "mjs"),
                 compact: context.options.minify,
                 dir: resolve(context.options.rootDir, context.options.outDir),
-                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, context.options.outputExtensionMap?.esm.js ?? "mjs"),
+                entryFileNames: (chunkInfo: PreRenderedAsset) => getEntryFileNames(chunkInfo, context.options.outputExtensionMap?.esm ?? "mjs"),
                 esModule: useEsModuleMark ?? "if-default-prop",
                 exports: "auto",
                 // turn off live bindings support (exports.* getters for re-exports)

--- a/packages/packem/src/rollup/utils/get-entry-file-names.ts
+++ b/packages/packem/src/rollup/utils/get-entry-file-names.ts
@@ -2,7 +2,7 @@ import type { PreRenderedAsset } from "rollup";
 
 const isWindows = process.platform === "win32";
 
-const getEntryFileNames = (chunkInfo: PreRenderedAsset, extension: "cjs" | "mjs"): string => {
+const getEntryFileNames = (chunkInfo: PreRenderedAsset, extension: string): string => {
     const pathSeparator = isWindows ? "\\" : "/";
 
     // @see https://github.com/rollup/rollup/pull/5686#issuecomment-2418464909 -> should be most of the time only one entry

--- a/packages/packem/src/types.ts
+++ b/packages/packem/src/types.ts
@@ -232,13 +232,7 @@ export interface BuildOptions {
     onSuccess?: string | (() => Promise<(() => Promise<void> | void) | undefined | void>);
     onSuccessTimeout?: number;
     outDir: string;
-    outputExtensionMap?: Record<
-        Format,
-        {
-            dts?: string;
-            js?: string;
-        }
-    >;
+    outputExtensionMap?: Record<Format, string>;
     rollup: RollupBuildOptions;
     rootDir: string;
     runtime?: "browser" | "node";
@@ -250,8 +244,6 @@ export interface BuildOptions {
 }
 
 export type BuildPreset = BuildConfig | (() => BuildConfig);
-
-export type Environment = "development" | "production" | undefined;
 
 export type InferEntriesResult = {
     entries: BuildEntry[];

--- a/packages/packem/src/types.ts
+++ b/packages/packem/src/types.ts
@@ -71,6 +71,10 @@ interface RollupDynamicImportVariablesOptions {
     warnOnError?: boolean;
 }
 
+export type Format = "cjs" | "esm";
+
+export type Environment = "production" | "development" | undefined;
+
 /**
  * In addition to basic `entries`, `presets`, and `hooks`,
  * there are also all the properties of `BuildOptions` except for BuildOption's `entries`.
@@ -228,6 +232,13 @@ export interface BuildOptions {
     onSuccess?: string | (() => Promise<(() => Promise<void> | void) | undefined | void>);
     onSuccessTimeout?: number;
     outDir: string;
+    outputExtensionMap?: Record<
+        Format,
+        {
+            dts?: string;
+            js?: string;
+        }
+    >;
     rollup: RollupBuildOptions;
     rootDir: string;
     runtime?: "browser" | "node";

--- a/packages/packem/src/utils/extract-export-filenames.ts
+++ b/packages/packem/src/utils/extract-export-filenames.ts
@@ -1,7 +1,7 @@
 import type { PackageJson } from "@visulima/package";
 
 import { RUNTIME_EXPORT_CONVENTIONS, SPECIAL_EXPORT_CONVENTIONS } from "../constants";
-import type { BuildOptions } from "../types";
+import type { BuildOptions, Format } from "../types";
 import { inferExportType, inferExportTypeFromFileName } from "./infer-export-type";
 
 // This Set contains keys representing various JavaScript runtime environments and module systems.
@@ -32,7 +32,7 @@ export type OutputDescriptor = {
     isExecutable?: true;
     key: "bin" | "exports" | "main" | "module" | "types";
     subKey?: typeof runtimeExportConventions | (NonNullable<unknown> & string);
-    type?: "cjs" | "esm";
+    type?: Format;
 };
 
 export const extractExportFilenames = (

--- a/packages/packem/src/utils/infer-export-type.ts
+++ b/packages/packem/src/utils/infer-export-type.ts
@@ -1,4 +1,6 @@
-export const inferExportTypeFromFileName = (filename: string): "cjs" | "esm" | undefined => {
+import type { Format } from "../types";
+
+export const inferExportTypeFromFileName = (filename: string): Format | undefined => {
     if (filename.endsWith(".mjs") || filename.endsWith(".d.mts")) {
         return "esm";
     }
@@ -10,7 +12,7 @@ export const inferExportTypeFromFileName = (filename: string): "cjs" | "esm" | u
     return undefined;
 };
 
-export const inferExportType = (condition: string, previousConditions: string[], packageType: "cjs" | "esm", filename?: string): "cjs" | "esm" => {
+export const inferExportType = (condition: string, previousConditions: string[], packageType: Format, filename?: string): Format => {
     if (condition === "module-sync") {
         return "esm";
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4097,10 +4097,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  balanced-match@3.0.1:
-    resolution: {integrity: sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==}
-    engines: {node: '>= 16'}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4145,12 +4141,11 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@4.0.1:
-    resolution: {integrity: sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==}
-    engines: {node: '>= 18'}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4541,6 +4536,9 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -13713,8 +13711,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@3.0.1: {}
-
   base64-js@1.5.1: {}
 
   before-after-hook@2.2.3: {}
@@ -13768,13 +13764,14 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@4.0.1:
-    dependencies:
-      balanced-match: 3.0.1
 
   braces@3.0.3:
     dependencies:
@@ -14213,6 +14210,8 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
+
+  concat-map@0.0.1: {}
 
   concat-stream@1.6.2:
     dependencies:
@@ -17954,11 +17953,11 @@ snapshots:
 
   minimatch@3.0.8:
     dependencies:
-      brace-expansion: 4.0.1
+      brace-expansion: 1.1.12
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 4.0.1
+      brace-expansion: 1.1.12
 
   minimatch@5.1.6:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing output file extensions for different module formats in the build configuration.
  - Introduced validation for custom output extension mappings to ensure correct configuration.

- **Refactor**
  - Improved type safety and consistency by introducing new type aliases for module formats and environments.
  - Updated function signatures and type annotations to use the new type aliases, enhancing maintainability and clarity.
  - Enhanced file extension handling across build outputs, stubs, and package validation to support dynamic extensions.
  - Refined output formatting and regex patterns for better handling of declaration files and extensions.

- **Tests**
  - Added tests verifying build output respects custom file extension configurations.
  - Added retry mechanism to TypeScript integration tests for improved stability.

- **Chores**
  - Updated ESLint configuration to disable CSS linting and expand ignored files and directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->