### PR TITLE
chore(release): @visulima/packem-rollup@1.0.0-alpha.39 [skip ci]\n\n## @visulima/packem-rollup [1.0.0-alpha.39](https://github.com/visulima/packem/compare/@visulima/packem-rollup@1.0.0-alpha.38...@visulima/packem-rollup@1.0.0-alpha.39) (2026-02-21)

### DIFF
--- a/packages/packem/__tests__/intigration/packem-transformers.test.ts
+++ b/packages/packem/__tests__/intigration/packem-transformers.test.ts
@@ -131,4 +131,49 @@ export { index as default };
         expect(readFileSync(`${temporaryDirectoryPath}/dist/index.cjs`)).toBe(expectedCjs);
         expect(readFileSync(`${temporaryDirectoryPath}/dist/index.mjs`)).toBe(expectedMjs);
     });
+
+    // Regression: the sucrase transformer used to enable the "imports" transform when the
+    // project's tsconfig set `esModuleInterop`, rewriting ESM `import`/`export` into CommonJS
+    // `require`/`exports`. Rollup does not follow `require()` in its module graph, so a
+    // relative import such as `require("./other")` was left as an unresolved runtime require
+    // and the imported module was never bundled — producing a near-empty bundle while the
+    // build still succeeded. This asserts the imported module's content survives in the output.
+    it.each(["esbuild", "swc", "sucrase", "oxc"] as const)(
+        "should bundle imported modules with the '%s' transformer when esModuleInterop is enabled",
+        async (transformer) => {
+            expect.assertions(4);
+
+            await installPackage(temporaryDirectoryPath, "typescript");
+
+            writeFileSync(`${temporaryDirectoryPath}/src/other.ts`, `export const marker = () => "BUNDLED_MARKER";`);
+            writeFileSync(
+                `${temporaryDirectoryPath}/src/index.ts`,
+                `import { marker } from "./other";\n\nexport default () => marker();`,
+            );
+
+            await createTsConfig(temporaryDirectoryPath, { compilerOptions: { esModuleInterop: true } });
+            await createPackageJson(
+                temporaryDirectoryPath,
+                {
+                    devDependencies: { typescript: "*" },
+                    main: "./dist/index.cjs",
+                    module: "./dist/index.mjs",
+                },
+                transformer,
+            );
+            await createPackemConfig(temporaryDirectoryPath, { transformer });
+
+            const binProcess = await execPackem("build", [], { cwd: temporaryDirectoryPath });
+
+            expect(binProcess.exitCode).toBe(0);
+
+            const cjs = readFileSync(`${temporaryDirectoryPath}/dist/index.cjs`);
+            const mjs = readFileSync(`${temporaryDirectoryPath}/dist/index.mjs`);
+
+            // The imported module's body must be inlined, not left as an unresolved require("./other").
+            expect(cjs).toContain("BUNDLED_MARKER");
+            expect(mjs).toContain("BUNDLED_MARKER");
+            expect(cjs).not.toMatch(/require\(["']\.\/other["']\)/);
+        },
+    );
 });

--- a/packages/packem/src/packem/index.ts
+++ b/packages/packem/src/packem/index.ts
@@ -366,16 +366,23 @@ const generateOptions = (
                 injectCreateRequireForImportRequire: false,
                 preserveDynamicImport: true,
                 production: environment === PRODUCTION_ENV,
+                // The sucrase "imports" transform rewrites ESM `import`/`export` into
+                // CommonJS `require`/`exports`. Rollup does not follow `require()` in its
+                // native module graph, so enabling it leaves relative imports (e.g.
+                // `require("./App")`) as unresolved external runtime requires — the rest of
+                // the module graph is never bundled, yielding a near-empty output while the
+                // build still succeeds. Keep sucrase emitting ESM (matching the
+                // esbuild/swc/oxc transformers) and let rollup link the graph itself.
                 ...tsconfig?.config.compilerOptions?.jsx && ["react", "react-jsx", "react-jsxdev"].includes(tsconfig.config.compilerOptions.jsx)
                     ? {
                         jsxFragmentPragma: tsconfig.config.compilerOptions.jsxFragmentFactory,
                         jsxImportSource: tsconfig.config.compilerOptions.jsxImportSource,
                         jsxPragma: tsconfig.config.compilerOptions.jsxFactory,
                         jsxRuntime,
-                        transforms: ["typescript", "jsx", ...tsconfig.config.compilerOptions.esModuleInterop ? ["imports"] : []],
+                        transforms: ["typescript", "jsx"],
                     }
                     : {
-                        transforms: ["typescript", ...tsconfig?.config.compilerOptions?.esModuleInterop ? ["imports"] : []],
+                        transforms: ["typescript"],
                     },
             },
             swc: {

--- a/packages/packem/src/types.ts
+++ b/packages/packem/src/types.ts
@@ -134,7 +134,14 @@ export interface BuildOptions {
     browserTargets?: string[];
     /** Custom builder functions for different build types */
     builder?: Record<string, (context: BuildContext<BuildOptions>, cachePath: string | undefined, fileCache: FileCache, logged: boolean) => Promise<void>>;
-    /** Bundler to use for building source files */
+    /**
+     * Bundler to use for building source files.
+     *
+     * Note: when set to `"rolldown"` the {@link transformer} option is ignored.
+     * Rolldown ships its own oxc-based transform and always uses it, so the
+     * esbuild/swc/sucrase/oxc transformer adapters only take effect under the
+     * default `"rollup"` bundler.
+     */
     bundler?: "rollup" | "rolldown";
     /** Whether to enable CommonJS interop for ESM modules */
     cjsInterop?: boolean;


### PR DESCRIPTION
### Features

* **packem-rollup:** add pure new expression plugin and update source ([48c4f00](https://github.com/visulima/packem/commit/48c4f0088d60ec5511f8a81645d4573f7deb38d5))

### Miscellaneous Chores

* remove empty optionalDependencies sections from package.json files ([a4aecaa](https://github.com/visulima/packem/commit/a4aecaaacb33d1ffcc8731cfc5247e5f7fa79cf0))

### Dependencies

* **@visulima/packem-share:** upgraded to 1.0.0-alpha.20