### PR TITLE
fix: bring examples up to date with latest packem (+ 3 packem fixes)

### DIFF
--- a/examples/cjs-interop/package.json
+++ b/examples/cjs-interop/package.json
@@ -2,9 +2,18 @@
     "name": "examples_packem_cjs_interop",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "commonjs",
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "typesVersions": {
+        "*": {
+            ".": [
+                "./dist/index.d.ts"
+            ]
+        }
+    },
     "files": [
         "./dist"
     ],

--- a/examples/copy/package.json
+++ b/examples/copy/package.json
@@ -2,9 +2,18 @@
     "name": "examples_packem_copy",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "commonjs",
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "typesVersions": {
+        "*": {
+            ".": [
+                "./dist/index.d.ts"
+            ]
+        }
+    },
     "files": [
         "./dist"
     ],

--- a/examples/dynamic-imports/package.json
+++ b/examples/dynamic-imports/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_dynamic-imports",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -11,6 +12,14 @@
     },
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "typesVersions": {
+        "*": {
+            ".": [
+                "./dist/index.d.ts"
+            ]
+        }
+    },
     "files": [
         "./dist"
     ],

--- a/examples/esm-cjs-exports/package.json
+++ b/examples/esm-cjs-exports/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_esm_cjs_exports",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {

--- a/examples/ignore-export-keys/package.json
+++ b/examples/ignore-export-keys/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_ignore_export_keys",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": "./dist/index.js",

--- a/examples/mixed/package.json
+++ b/examples/mixed/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_mixed",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "description": "",
     "type": "commonjs",
     "exports": {
@@ -81,10 +82,6 @@
     "scripts": {
         "build": "packem build",
         "clean": "rimraf node_modules dist"
-    },
-    "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
     },
     "devDependencies": {
         "@types/node": "25.9.1",

--- a/examples/multi-exports/package.json
+++ b/examples/multi-exports/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_multi_exports",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -58,8 +59,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@types/react": "^19.2.16",

--- a/examples/native-node-module/package.json
+++ b/examples/native-node-module/package.json
@@ -2,10 +2,18 @@
     "name": "examples_packem_native_node_module",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "commonjs",
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
+    "typesVersions": {
+        "*": {
+            ".": [
+                "./dist/index.d.ts"
+            ]
+        }
+    },
     "files": [
         "./dist"
     ],

--- a/examples/react-tailwindcss-v4-oxide/package.json
+++ b/examples/react-tailwindcss-v4-oxide/package.json
@@ -1,6 +1,9 @@
 {
     "name": "examples_packem_react_tailwindcss-v4-oxide",
     "private": true,
+    "sideEffects": [
+        "**/*.css"
+    ],
     "keywords": [
         "tailwind",
         "tailwind-oxide",

--- a/examples/react-tailwindcss-v4/package.json
+++ b/examples/react-tailwindcss-v4/package.json
@@ -2,6 +2,9 @@
     "name": "examples_packem_react_tailwindcss-v4",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": [
+        "**/*.css"
+    ],
     "type": "module",
     "exports": [
         "./dist/index.mjs",

--- a/examples/react-tsx-css-module/package.json
+++ b/examples/react-tsx-css-module/package.json
@@ -2,6 +2,9 @@
     "name": "examples_packem_react_tsx_css-module",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": [
+        "**/*.css"
+    ],
     "type": "module",
     "exports": [
         "./dist/index.cjs",
@@ -18,8 +21,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@types/react": "^19.2.16",

--- a/examples/react-tsx/package.json
+++ b/examples/react-tsx/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_react_tsx",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {

--- a/examples/react-use-client/package.json
+++ b/examples/react-use-client/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_react_use_client",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -35,8 +36,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@types/react": "^19.2.16",

--- a/examples/styles-inject/package.json
+++ b/examples/styles-inject/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_styles_inject",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": true,
     "type": "module",
     "exports": [
         "./dist/index.cjs",

--- a/examples/styles-inject/packem.config.ts
+++ b/examples/styles-inject/packem.config.ts
@@ -9,6 +9,7 @@ import cssnanoMinifier from "@visulima/packem/css/minifier/cssnano";
 
 export default defineConfig({
     transformer,
+    declaration: false,
     rollup: {
         css: {
             mode: "inject",

--- a/examples/styles/package.json
+++ b/examples/styles/package.json
@@ -2,6 +2,9 @@
     "name": "examples_packem_styles",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": [
+        "**/*.css"
+    ],
     "type": "module",
     "exports": [
         "./dist/index.cjs",

--- a/examples/styles/packem.config.ts
+++ b/examples/styles/packem.config.ts
@@ -9,6 +9,7 @@ import cssnanoMinifier from "@visulima/packem/css/minifier/cssnano";
 
 export default defineConfig({
     transformer,
+    declaration: false,
     rollup: {
         css: {
             mode: "extract",

--- a/examples/transformer-esbuild/package.json
+++ b/examples/transformer-esbuild/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_transformer_esbuild",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -33,8 +34,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@types/react": "^19.2.16",

--- a/examples/transformer-oxc/package.json
+++ b/examples/transformer-oxc/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_transformer_oxc",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -33,8 +34,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@types/react": "^19.2.16",

--- a/examples/transformer-sucrase/package.json
+++ b/examples/transformer-sucrase/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_transformer_sucrase",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -33,8 +34,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@types/react": "^19.2.16",

--- a/examples/transformer-swc/package.json
+++ b/examples/transformer-swc/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_transformer_swc",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {
@@ -33,8 +34,7 @@
         "clean": "rimraf node_modules dist"
     },
     "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.7"
     },
     "devDependencies": {
         "@swc/core": "^1.15.40",

--- a/examples/typedoc/package.json
+++ b/examples/typedoc/package.json
@@ -2,6 +2,7 @@
     "name": "examples_packem_typedoc",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "type": "module",
     "exports": {
         ".": {

--- a/examples/types-entries/package.json
+++ b/examples/types-entries/package.json
@@ -2,8 +2,20 @@
     "name": "examples_packem_type_entries",
     "version": "1.0.0",
     "private": true,
-    "main": "./dist/index.cjs",
-    "types": "./types/index.types.ts",
+    "sideEffects": false,
+    "exports": {
+        ".": {
+            "types": "./dist/types/index.types.d.ts"
+        }
+    },
+    "types": "./dist/types/index.types.d.ts",
+    "typesVersions": {
+        "*": {
+            ".": [
+                "./dist/types/index.types.d.ts"
+            ]
+        }
+    },
     "files": [
         "./dist"
     ],

--- a/examples/types-entries/packem.config.ts
+++ b/examples/types-entries/packem.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
     entries: ["./types/*.types.ts"],
     declaration: true,
     transformer,
+    // This package ships type declarations only (no runtime entry), so there is
+    // intentionally no `main` field to validate.
+    validation: {
+        packageJson: {
+            main: false,
+        },
+    },
     rollup: {
         node10Compatibility: {
             writeToPackageJson: true,

--- a/examples/types-entries/tsconfig.json
+++ b/examples/types-entries/tsconfig.json
@@ -15,5 +15,5 @@
             "@/*": ["./src/*"]
         }
     },
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "types/**/*.ts"]
 }

--- a/examples/types-entries/types/index.types.ts
+++ b/examples/types-entries/types/index.types.ts
@@ -1,3 +1,3 @@
-import { InterfaceA, InterfaceB } from "@/demo";
+import { InterfaceA, InterfaceB } from "../src/demo";
 
 export type TypeC = InterfaceA | InterfaceB;

--- a/examples/typescript-tsconfig-paths/package.json
+++ b/examples/typescript-tsconfig-paths/package.json
@@ -2,7 +2,9 @@
     "name": "examples_packem_typescript_tsconfig_paths",
     "version": "1.0.0",
     "private": true,
+    "sideEffects": false,
     "main": "./dist/index.cjs",
+    "types": "./dist/index.d.ts",
     "files": [
         "./dist"
     ],

--- a/packages/packem-plugins/__tests__/unit/plugins/debarrel.test.ts
+++ b/packages/packem-plugins/__tests__/unit/plugins/debarrel.test.ts
@@ -114,6 +114,26 @@ describe(debarrelPlugin, () => {
         expect(result).toBeUndefined();
     });
 
+    it("should skip virtual modules and query-suffixed ids", async () => {
+        expect.assertions(3);
+
+        const plugin = debarrelPlugin({}, mockLogger as unknown as Console);
+
+        const mockContext = {
+            resolve: mockResolve,
+        } as unknown as ThisParameterType<TransformHandler>;
+
+        // Vue/Svelte SFC sub-modules carry a `?query` yet can end in a source
+        // extension; a rolled-up commonjs/virtual module is `\0`-prefixed. Neither
+        // exists on disk, so debarrel must skip them instead of readFile-ing the id.
+        const sfc = await getTransformHandler(plugin).call(mockContext, "code", "/test/App.vue?vue&type=script&setup=true&lang.ts", { ssr: false });
+        const virtual = await getTransformHandler(plugin).call(mockContext, "code", "\0virtual:module.ts", { ssr: false });
+
+        expect(sfc).toBeUndefined();
+        expect(virtual).toBeUndefined();
+        expect(fs.readFile).not.toHaveBeenCalled();
+    });
+
     it("should cache file reads", async () => {
         expect.assertions(2);
 

--- a/packages/packem-plugins/src/plugins/debarrel.ts
+++ b/packages/packem-plugins/src/plugins/debarrel.ts
@@ -531,6 +531,15 @@ export const debarrelPlugin = (options: DebarrelPluginOptions, logger: Console):
         },
 
         async transform(code, id) {
+            // Skip virtual modules and query-suffixed ids (e.g. Vue/Svelte SFC
+            // sub-modules like `App.vue?vue&type=script&lang.ts`, commonjs proxies).
+            // These are not on-disk barrel files, yet their id can end in a source
+            // extension; getDebarrelModifications reads the source by id from disk,
+            // so passing a virtual id through would throw ENOENT.
+            if (id.includes("\0") || id.includes("?")) {
+                return undefined;
+            }
+
             if (!isSourceFile(id)) {
                 return undefined;
             }

--- a/packages/packem/__tests__/intigration/package-json-exports.test.ts
+++ b/packages/packem/__tests__/intigration/package-json-exports.test.ts
@@ -201,6 +201,59 @@ export function method() {
         }
     });
 
+    it("should emit base declarations for the default entry alongside dev/prod conditions", async () => {
+        expect.assertions(7);
+
+        writeFileSync(`${temporaryDirectoryPath}/src/index.ts`, `export const value: string = process.env.NODE_ENV ?? "";`);
+
+        await installPackage(temporaryDirectoryPath, "typescript");
+        await createTsConfig(temporaryDirectoryPath);
+        await createPackemConfig(temporaryDirectoryPath);
+        // The default/import/require entries share the `node` runtime with the
+        // development/production siblings. The DTS plugin used to be memoized
+        // across these parallel environment builds, so the default entry's
+        // declaration collapsed to an empty facade and `index.d.mts`/`.d.cts`
+        // were never written. They must be emitted here.
+        await createPackageJson(temporaryDirectoryPath, {
+            devDependencies: {
+                typescript: "*",
+            },
+            exports: {
+                ".": {
+                    import: {
+                        default: "./dist/index.mjs",
+                        development: "./dist/index.development.mjs",
+                        production: "./dist/index.production.mjs",
+                        types: "./dist/index.d.mts",
+                    },
+                    require: {
+                        default: "./dist/index.cjs",
+                        development: "./dist/index.development.cjs",
+                        production: "./dist/index.production.cjs",
+                        types: "./dist/index.d.cts",
+                    },
+                },
+            },
+        });
+
+        const binProcess = await execPackem("build", ["--no-environment"], {
+            cwd: temporaryDirectoryPath,
+        });
+
+        expect(binProcess.exitCode).toBe(0);
+
+        // Base (default-condition) declarations — the regression.
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.mts`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.cts`)).toBe(true);
+        // The default-entry declaration must carry the real type, not be an empty facade.
+        expect(readFileSync(`${temporaryDirectoryPath}/dist/index.d.mts`)).toContain("value");
+        expect(readFileSync(`${temporaryDirectoryPath}/dist/index.d.cts`)).toContain("value");
+
+        // Environment-specific declarations remain emitted too.
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.development.d.mts`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.production.d.cts`)).toBe(true);
+    });
+
     it("should work with dev and prod optimize conditions in nested-convention", async () => {
         expect.assertions(14);
 

--- a/packages/packem/__tests__/intigration/unbundle.test.ts
+++ b/packages/packem/__tests__/intigration/unbundle.test.ts
@@ -235,4 +235,208 @@ export { b } from './b/indexB';
         expect(indexBjs).toContain("const b");
         expect(indexBjs).toContain("export { b }");
     });
+
+    it("should infer emit formats from package.json without explicit emitESM/failOnWarn", async () => {
+        expect.assertions(5);
+
+        await writeFile(
+            `${temporaryDirectoryPath}/src/a/indexA.ts`,
+            `export const a = 'a';
+`,
+        );
+        await writeFile(
+            `${temporaryDirectoryPath}/src/index.ts`,
+            `export { a } from './a/indexA';
+`,
+        );
+
+        await installPackage(temporaryDirectoryPath, "typescript");
+        // ESM package whose exports only carry a `default` + `types`: unbundle
+        // mode must still infer ESM + declarations from this (the regression —
+        // previously it emitted nothing and failed validation on the missing files).
+        await createPackageJson(temporaryDirectoryPath, {
+            devDependencies: { typescript: "*" },
+            engines: { node: ">=20" },
+            exports: {
+                ".": {
+                    default: "./dist/index.js",
+                    types: "./dist/index.d.ts",
+                },
+            },
+            type: "module",
+        });
+        await createTsConfig(temporaryDirectoryPath, {
+            compilerOptions: { rootDir: "./src" },
+        });
+        await createPackemConfig(temporaryDirectoryPath, {
+            config: {
+                unbundle: true,
+            },
+        });
+
+        const binProcess = await execPackem("build", [], {
+            cwd: temporaryDirectoryPath,
+        });
+
+        // No failOnWarn override: a clean build proves the emitted files match
+        // the package.json exports (index.js + index.d.ts) and the source
+        // structure is preserved.
+        expect(binProcess.exitCode).toBe(0);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.js`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.ts`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/a/indexA.js`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/a/indexA.d.ts`)).toBe(true);
+    });
+
+    it("should infer CJS + declarations from a commonjs package.json", async () => {
+        expect.assertions(5);
+
+        await writeFile(`${temporaryDirectoryPath}/src/a/indexA.ts`, `export const a = 'a';\n`);
+        await writeFile(`${temporaryDirectoryPath}/src/index.ts`, `export { a } from './a/indexA';\n`);
+
+        await installPackage(temporaryDirectoryPath, "typescript");
+        await createPackageJson(temporaryDirectoryPath, {
+            devDependencies: { typescript: "*" },
+            engines: { node: ">=20" },
+            exports: {
+                ".": {
+                    require: "./dist/index.js",
+                    types: "./dist/index.d.ts",
+                },
+            },
+            type: "commonjs",
+        });
+        await createTsConfig(temporaryDirectoryPath, {
+            compilerOptions: { rootDir: "./src" },
+        });
+        await createPackemConfig(temporaryDirectoryPath, {
+            config: {
+                unbundle: true,
+            },
+        });
+
+        const binProcess = await execPackem("build", [], { cwd: temporaryDirectoryPath });
+
+        // preserveModules emits `.js` for the chosen format; type:commonjs makes
+        // those files CommonJS. No `.mjs` should be emitted (ESM not inferred).
+        expect(binProcess.exitCode).toBe(0);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.js`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.ts`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/a/indexA.js`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.mjs`)).toBe(false);
+    });
+
+    it("should infer dual ESM+CJS formats from import/require conditions", async () => {
+        expect.assertions(6);
+
+        await writeFile(`${temporaryDirectoryPath}/src/a/indexA.ts`, `export const a = 'a';\n`);
+        await writeFile(`${temporaryDirectoryPath}/src/index.ts`, `export { a } from './a/indexA';\n`);
+
+        await installPackage(temporaryDirectoryPath, "typescript");
+        await createPackageJson(temporaryDirectoryPath, {
+            devDependencies: { typescript: "*" },
+            engines: { node: ">=20" },
+            exports: {
+                ".": {
+                    import: "./dist/index.js",
+                    require: "./dist/index.cjs",
+                    types: { import: "./dist/index.d.mts", require: "./dist/index.d.cts" },
+                },
+            },
+            type: "module",
+        });
+        await createTsConfig(temporaryDirectoryPath, {
+            compilerOptions: { rootDir: "./src" },
+        });
+        await createPackemConfig(temporaryDirectoryPath, {
+            config: {
+                unbundle: true,
+            },
+        });
+
+        const binProcess = await execPackem("build", [], { cwd: temporaryDirectoryPath });
+
+        // ESM stays `.js` (type:module); CJS disambiguates as `.cjs`. Both
+        // declaration flavors are emitted. Source structure is preserved.
+        expect(binProcess.exitCode).toBe(0);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.js`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.cjs`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.mts`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.cts`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/a/indexA.cjs`)).toBe(true);
+    });
+
+    it("should not emit declarations when the package.json declares no types", async () => {
+        expect.assertions(3);
+
+        await writeFile(`${temporaryDirectoryPath}/src/a/indexA.ts`, `export const a = 'a';\n`);
+        await writeFile(`${temporaryDirectoryPath}/src/index.ts`, `export { a } from './a/indexA';\n`);
+
+        await installPackage(temporaryDirectoryPath, "typescript");
+        await createPackageJson(temporaryDirectoryPath, {
+            devDependencies: { typescript: "*" },
+            engines: { node: ">=20" },
+            exports: {
+                ".": {
+                    default: "./dist/index.js",
+                },
+            },
+            type: "module",
+        });
+        await createTsConfig(temporaryDirectoryPath, {
+            compilerOptions: { rootDir: "./src" },
+        });
+        await createPackemConfig(temporaryDirectoryPath, {
+            config: {
+                unbundle: true,
+            },
+        });
+
+        const binProcess = await execPackem("build", [], { cwd: temporaryDirectoryPath });
+
+        // No `types` anywhere -> declaration inference is disabled -> JS only.
+        expect(binProcess.exitCode).toBe(0);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.js`)).toBe(true);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.d.ts`)).toBe(false);
+    });
+
+    it("should respect an explicit emitCJS over package-type inference", async () => {
+        expect.assertions(3);
+
+        await writeFile(`${temporaryDirectoryPath}/src/index.ts`, `export const value = 'a';\n`);
+
+        await installPackage(temporaryDirectoryPath, "typescript");
+        // type:module would infer ESM, but an explicit emitCJS must win. In
+        // preserveModules the file stays `index.js`, so assert on the emitted
+        // module format (CommonJS) rather than the extension.
+        await createPackageJson(temporaryDirectoryPath, {
+            devDependencies: { typescript: "*" },
+            engines: { node: ">=20" },
+            exports: {
+                ".": {
+                    require: "./dist/index.js",
+                },
+            },
+            type: "module",
+        });
+        await createTsConfig(temporaryDirectoryPath, {
+            compilerOptions: { rootDir: "./src" },
+        });
+        await createPackemConfig(temporaryDirectoryPath, {
+            config: {
+                emitCJS: true,
+                unbundle: true,
+            },
+        });
+
+        const binProcess = await execPackem("build", [], { cwd: temporaryDirectoryPath });
+
+        expect(binProcess.exitCode).toBe(0);
+        expect(existsSync(`${temporaryDirectoryPath}/dist/index.js`)).toBe(true);
+
+        // CommonJS output (explicit emitCJS), not the ESM that type:module infers.
+        const indexJs = normalizeBundleOutput(readFileSync(`${temporaryDirectoryPath}/dist/index.js`));
+
+        expect(indexJs).toContain("exports");
+    });
 });

--- a/packages/packem/__tests__/unit/validator/package-json/validate-package-fields.test.ts
+++ b/packages/packem/__tests__/unit/validator/package-json/validate-package-fields.test.ts
@@ -891,7 +891,7 @@ describe(validatePackageFields, () => {
             );
         });
 
-        it("should warn on conflicting development and production conditions", () => {
+        it("should accept both development and production conditions together", () => {
             expect.assertions(1);
 
             const context = {
@@ -915,10 +915,10 @@ describe(validatePackageFields, () => {
 
             validatePackageFields(context as unknown as BuildContext<InternalBuildOptions>);
 
-            expect(mockedWarn).toHaveBeenCalledExactlyOnceWith(
-                context,
-                "Conflicting conditions \"development\" and \"production\" at exports. These conditions are mutually exclusive",
-            );
+            // Declaring both `development` and `production` is a valid, intended
+            // pattern (a package shipping a separate build per condition); the
+            // resolver only ever activates one. It must not produce a warning.
+            expect(mockedWarn).not.toHaveBeenCalled();
         });
 
         it("should accept null values to block subpaths", () => {

--- a/packages/packem/src/config/preset/auto.ts
+++ b/packages/packem/src/config/preset/auto.ts
@@ -85,94 +85,131 @@ interface AutoPresetLogger {
     warn: (...arguments_: unknown[]) => void;
 }
 
+/**
+ * Resolves and stores `emitESM`/`emitCJS` for unbundle mode (which skips
+ * {@link inferEntries}). Mirrors the package.json signals `inferEntries` reads,
+ * but only when neither flag is set explicitly by the user.
+ * @param context The build context (mutated in place).
+ * @param conditions Export condition keys referenced by package.json.
+ * @param files Output file paths referenced by package.json.
+ */
+const resolveUnbundleEmitFormats = (context: BuildContext<InternalBuildOptions>, conditions: Set<string>, files: string[]): void => {
+    if (context.options.emitESM !== undefined || context.options.emitCJS !== undefined) {
+        return;
+    }
+
+    const packageType: "cjs" | "esm" = context.pkg.type === "module" ? "esm" : "cjs";
+    const hasPlainJs = files.some((file) => JS_OUTPUT_REGEXP.test(file));
+
+    let emitESM = files.some((file) => MJS_OUTPUT_REGEXP.test(file)) || conditions.has("import") || conditions.has("module");
+    let emitCJS = files.some((file) => CJS_OUTPUT_REGEXP.test(file)) || conditions.has("require");
+
+    // Plain `.js` (and the no-signal fallback) follow the package type.
+    if ((hasPlainJs || (!emitESM && !emitCJS)) && packageType === "esm") {
+        emitESM = true;
+    } else if (hasPlainJs || (!emitESM && !emitCJS)) {
+        emitCJS = true;
+    }
+
+    context.options.emitESM = emitESM;
+    context.options.emitCJS = emitCJS;
+};
+
+/**
+ * Resolves and stores `declaration` for unbundle mode: respects an explicit
+ * config/CLI value, otherwise enables it when package.json references types.
+ * @param context The build context (mutated in place).
+ * @param conditions Export condition keys referenced by package.json.
+ * @param files Output file paths referenced by package.json.
+ */
+const resolveUnbundleDeclaration = (context: BuildContext<InternalBuildOptions>, conditions: Set<string>, files: string[]): void => {
+    if (context.options.declaration !== undefined) {
+        return;
+    }
+
+    const hasTypes = Boolean(context.pkg.types) || conditions.has("types") || files.some((file) => DECLARATION_OUTPUT_REGEXP.test(file));
+
+    context.options.declaration = hasTypes ? "node16" : false;
+};
+
+/**
+ * Builds one entry per source file for unbundle mode (preserving the source
+ * tree) and resolves the emit-format flags package.json implies.
+ *
+ * Unbundle mode skips {@link inferEntries}, so without this the emit-format
+ * flags stay unset, every entry has neither `cjs` nor `esm`, and nothing is
+ * emitted ("Emitting of ESM/CJS bundles is disabled").
+ * @param context The build context (its `options.entries` is replaced in place).
+ */
+const prepareUnbundleEntries = (context: BuildContext<InternalBuildOptions>): void => {
+    context.options.entries.length = 0;
+
+    const sourceDirectory = join(context.options.rootDir, context.options.sourceDir);
+
+    if (!isAccessibleSync(sourceDirectory)) {
+        throw new Error("No 'src' directory found. Please provide entries manually.");
+    }
+
+    const sourceFiles = collectSync(sourceDirectory, {
+        extensions: [],
+        includeDirs: false,
+        includeSymlinks: false,
+        skip: [EXCLUDE_REGEXP, DIST_PATH_REGEXP],
+    });
+
+    // Filter for TypeScript/JavaScript files
+    const codeFiles = sourceFiles.filter((file) => ALLOWED_TRANSFORM_EXTENSIONS_REGEX.test(file) && !file.endsWith(".d.ts"));
+
+    const { conditions, files } = collectPackageOutputs(context.pkg as NormalizedPackageJson);
+
+    resolveUnbundleEmitFormats(context, conditions, files);
+    resolveUnbundleDeclaration(context, conditions, files);
+
+    const emitESM = context.options.emitESM ?? false;
+    const emitCJS = context.options.emitCJS ?? false;
+
+    for (const file of codeFiles) {
+        const relativePath = file.replace(`${sourceDirectory}/`, "");
+        const name = relativePath.replace(ALLOWED_TRANSFORM_EXTENSIONS_REGEX, "").replaceAll("/", "/");
+
+        context.options.entries.push({
+            cjs: emitCJS,
+            declaration: context.options.declaration,
+            esm: emitESM,
+            input: file,
+            name,
+        });
+    }
+
+    const tags: string[] = [];
+
+    if (emitESM) {
+        tags.push("[esm]");
+    }
+
+    if (emitCJS) {
+        tags.push("[cjs]");
+    }
+
+    if (context.options.declaration) {
+        tags.push("[dts]");
+    }
+
+    const entryCount = context.options.entries.length;
+
+    (context.logger as AutoPresetLogger).info(
+        "Unbundle mode: preserving source structure for",
+        cyan(`${String(entryCount)} ${entryCount === 1 ? "entry" : "entries"}`),
+        gray(tags.join(" ")),
+    );
+};
+
 const autoPreset: BuildConfig = {
     hooks: {
         "build:prepare": async function (context: BuildContext<InternalBuildOptions>) {
             // For unbundle mode, always create entries for all source files
             if (context.options.unbundle) {
-                // Clear existing entries
-                context.options.entries.length = 0;
-
-                const sourceDirectory = join(context.options.rootDir, context.options.sourceDir);
-
-                if (!isAccessibleSync(sourceDirectory)) {
-                    throw new Error("No 'src' directory found. Please provide entries manually.");
-                }
-
-                const sourceFiles = collectSync(sourceDirectory, {
-                    extensions: [],
-                    includeDirs: false,
-                    includeSymlinks: false,
-                    skip: [EXCLUDE_REGEXP, DIST_PATH_REGEXP],
-                });
-
-                // Filter for TypeScript/JavaScript files
-                const codeFiles = sourceFiles.filter((file) => ALLOWED_TRANSFORM_EXTENSIONS_REGEX.test(file) && !file.endsWith(".d.ts"));
-
-                // Unbundle mode skips inferEntries, so the emit-format flags it
-                // normally derives from package.json are still unset here. Without
-                // them every entry has neither `cjs` nor `esm` set and nothing is
-                // emitted ("Emitting of ESM/CJS bundles is disabled"). Derive the
-                // formats from the same package.json signals inferEntries uses —
-                // but only when the user has not configured them explicitly.
-                const { conditions, files } = collectPackageOutputs(context.pkg as NormalizedPackageJson);
-
-                if (context.options.emitESM === undefined && context.options.emitCJS === undefined) {
-                    const packageType: "cjs" | "esm" = context.pkg.type === "module" ? "esm" : "cjs";
-                    const hasPlainJs = files.some((file) => JS_OUTPUT_REGEXP.test(file));
-
-                    let emitESM
-                        = files.some((file) => MJS_OUTPUT_REGEXP.test(file)) || conditions.has("import") || conditions.has("module") || (hasPlainJs && packageType === "esm");
-                    let emitCJS = files.some((file) => CJS_OUTPUT_REGEXP.test(file)) || conditions.has("require") || (hasPlainJs && packageType === "cjs");
-
-                    // Fall back to the package type when the package.json carries no
-                    // format-specific signal (e.g. exports with only a `default`).
-                    if (!emitESM && !emitCJS) {
-                        if (packageType === "esm") {
-                            emitESM = true;
-                        } else {
-                            emitCJS = true;
-                        }
-                    }
-
-                    context.options.emitESM = emitESM;
-                    context.options.emitCJS = emitCJS;
-                }
-
-                const emitESM = context.options.emitESM ?? false;
-                const emitCJS = context.options.emitCJS ?? false;
-
-                // Respect an explicit `declaration` (config/CLI); otherwise enable
-                // it when the package references type declarations.
-                if (context.options.declaration === undefined) {
-                    const hasTypes = Boolean(context.pkg.types) || conditions.has("types") || files.some((file) => DECLARATION_OUTPUT_REGEXP.test(file));
-
-                    context.options.declaration = hasTypes ? "node16" : false;
-                }
-
-                for (const file of codeFiles) {
-                    const relativePath = file.replace(`${sourceDirectory}/`, "");
-                    const name = relativePath.replace(ALLOWED_TRANSFORM_EXTENSIONS_REGEX, "").replaceAll("/", "/");
-
-                    context.options.entries.push({
-                        cjs: emitCJS,
-                        declaration: context.options.declaration,
-                        esm: emitESM,
-                        input: file,
-                        name,
-                    });
-                }
-
-                (context.logger as AutoPresetLogger).info(
-                    "Unbundle mode: preserving source structure for",
-                    cyan(`${String(context.options.entries.length)} entr${context.options.entries.length === 1 ? "y" : "ies"}`),
-                    gray(
-                        [emitESM && "esm", emitCJS && "cjs", context.options.declaration && "dts"]
-                            .filter(Boolean)
-                            .map((tag) => `[${String(tag)}]`)
-                            .join(" "),
-                    ),
-                );
+                prepareUnbundleEntries(context);
 
                 // Don't run the normal auto logic
                 return;

--- a/packages/packem/src/config/preset/auto.ts
+++ b/packages/packem/src/config/preset/auto.ts
@@ -14,6 +14,64 @@ const DIST_PATH_REGEXP = /.*\/dist\/.*/;
 
 const TRAILING_SLASH_REGEXP = /\/$/;
 
+const MJS_OUTPUT_REGEXP = /\.mjs$/;
+const CJS_OUTPUT_REGEXP = /\.cjs$/;
+const DECLARATION_OUTPUT_REGEXP = /\.d\.[mc]?ts$/;
+// Plain `.js` that is not a declaration file; its format depends on package type.
+const JS_OUTPUT_REGEXP = /(?<!\.d)\.js$/;
+
+/**
+ * Collects every output file path and condition key referenced by a
+ * package.json's `exports`/`main`/`module`/`types`. Used to derive emit formats
+ * in unbundle mode, which skips {@link inferEntries}.
+ * @param packageJson The package manifest to scan.
+ * @returns Referenced output file paths and the set of export condition keys.
+ */
+const collectPackageOutputs = (packageJson: NormalizedPackageJson): { conditions: Set<string>; files: string[] } => {
+    const files: string[] = [];
+    const conditions = new Set<string>();
+
+    const walk = (value: unknown): void => {
+        if (typeof value === "string") {
+            files.push(value);
+
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                walk(item);
+            }
+
+            return;
+        }
+
+        if (value && typeof value === "object") {
+            for (const [key, nested] of Object.entries(value)) {
+                // Subpath keys start with "." (e.g. "./core"); everything else is
+                // a condition name (import, require, types, node, development, …).
+                if (!key.startsWith(".")) {
+                    conditions.add(key);
+                }
+
+                walk(nested);
+            }
+        }
+    };
+
+    if (packageJson.exports) {
+        walk(packageJson.exports);
+    }
+
+    for (const field of [packageJson.main, packageJson.module, packageJson.types]) {
+        if (typeof field === "string") {
+            files.push(field);
+        }
+    }
+
+    return { conditions, files };
+};
+
 /**
  * Minimal structural view of the {@link BuildContext}'s `logger` (a `Pail`
  * instance). The `@visulima/pail` package's export map is not resolvable by
@@ -51,15 +109,70 @@ const autoPreset: BuildConfig = {
                 // Filter for TypeScript/JavaScript files
                 const codeFiles = sourceFiles.filter((file) => ALLOWED_TRANSFORM_EXTENSIONS_REGEX.test(file) && !file.endsWith(".d.ts"));
 
+                // Unbundle mode skips inferEntries, so the emit-format flags it
+                // normally derives from package.json are still unset here. Without
+                // them every entry has neither `cjs` nor `esm` set and nothing is
+                // emitted ("Emitting of ESM/CJS bundles is disabled"). Derive the
+                // formats from the same package.json signals inferEntries uses —
+                // but only when the user has not configured them explicitly.
+                const { conditions, files } = collectPackageOutputs(context.pkg as NormalizedPackageJson);
+
+                if (context.options.emitESM === undefined && context.options.emitCJS === undefined) {
+                    const packageType: "cjs" | "esm" = context.pkg.type === "module" ? "esm" : "cjs";
+                    const hasPlainJs = files.some((file) => JS_OUTPUT_REGEXP.test(file));
+
+                    let emitESM
+                        = files.some((file) => MJS_OUTPUT_REGEXP.test(file)) || conditions.has("import") || conditions.has("module") || (hasPlainJs && packageType === "esm");
+                    let emitCJS = files.some((file) => CJS_OUTPUT_REGEXP.test(file)) || conditions.has("require") || (hasPlainJs && packageType === "cjs");
+
+                    // Fall back to the package type when the package.json carries no
+                    // format-specific signal (e.g. exports with only a `default`).
+                    if (!emitESM && !emitCJS) {
+                        if (packageType === "esm") {
+                            emitESM = true;
+                        } else {
+                            emitCJS = true;
+                        }
+                    }
+
+                    context.options.emitESM = emitESM;
+                    context.options.emitCJS = emitCJS;
+                }
+
+                const emitESM = context.options.emitESM ?? false;
+                const emitCJS = context.options.emitCJS ?? false;
+
+                // Respect an explicit `declaration` (config/CLI); otherwise enable
+                // it when the package references type declarations.
+                if (context.options.declaration === undefined) {
+                    const hasTypes = Boolean(context.pkg.types) || conditions.has("types") || files.some((file) => DECLARATION_OUTPUT_REGEXP.test(file));
+
+                    context.options.declaration = hasTypes ? "node16" : false;
+                }
+
                 for (const file of codeFiles) {
                     const relativePath = file.replace(`${sourceDirectory}/`, "");
                     const name = relativePath.replace(ALLOWED_TRANSFORM_EXTENSIONS_REGEX, "").replaceAll("/", "/");
 
                     context.options.entries.push({
+                        cjs: emitCJS,
+                        declaration: context.options.declaration,
+                        esm: emitESM,
                         input: file,
                         name,
                     });
                 }
+
+                (context.logger as AutoPresetLogger).info(
+                    "Unbundle mode: preserving source structure for",
+                    cyan(`${String(context.options.entries.length)} entr${context.options.entries.length === 1 ? "y" : "ies"}`),
+                    gray(
+                        [emitESM && "esm", emitCJS && "cjs", context.options.declaration && "dts"]
+                            .filter(Boolean)
+                            .map((tag) => `[${String(tag)}]`)
+                            .join(" "),
+                    ),
+                );
 
                 // Don't run the normal auto logic
                 return;

--- a/packages/packem/src/packem/index.ts
+++ b/packages/packem/src/packem/index.ts
@@ -21,6 +21,7 @@ import type { RollupError } from "rollup";
 import type { Result as ExecChild } from "tinyexec";
 import { exec } from "tinyexec";
 
+import { version as packemVersion } from "../../package.json";
 import { resolveBundlerName } from "../bundler/build";
 import { ensureBundlerInstalled, ensureTransformerInstalled } from "../bundler/ensure-installed";
 import autoPreset from "../config/preset/auto";
@@ -863,6 +864,7 @@ const packem = async (
     const cacheKey
         = getCacheHash(
             JSON.stringify({
+                packemVersion,
                 version: packageJson.version,
                 ...packageJson.dependencies,
                 ...packageJson.devDependencies,

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -908,7 +908,22 @@ export const getRollupDtsOptions = async (context: BuildContext<InternalBuildOpt
     // re-used for later builds, which breaks direct-bypass inlining for devDeps that only
     // showed up after the first build finished.
     const resolveKey = computeDtsResolveKey(dtsResolve);
-    const uniqueProcessId = `dts-plugin:${String(process.pid)}${context.tsconfig?.path ?? ""}:${resolveKey}`;
+
+    // Include the build's entry set in the key. The per-environment/runtime DTS
+    // builds run in parallel (Promise.all), and `rollup-plugin-dts` is stateful
+    // (it holds a TS program and tracks emitted declarations). Environment
+    // siblings that share a runtime (e.g. the default vs development vs
+    // production groups, all `node`) would otherwise resolve to the same
+    // `resolveKey` and share a single plugin instance across concurrent builds —
+    // contaminating each other so the default entry's declaration collapses to an
+    // empty facade and its `.d.ts`/`.d.mts`/`.d.cts` never get written. Keying on
+    // the entry names gives each distinct build its own instance.
+    const entriesKey = context.options.entries
+        .map((entry) => entry.name)
+        .filter(Boolean)
+        .sort()
+        .join(",");
+    const uniqueProcessId = `dts-plugin:${String(process.pid)}${context.tsconfig?.path ?? ""}:${resolveKey}:${entriesKey}`;
 
     const [prePlugins, normalPlugins, postPlugins] = sortUserPlugins(context.options.rollup.plugins, "dts");
 

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -919,9 +919,9 @@ export const getRollupDtsOptions = async (context: BuildContext<InternalBuildOpt
     // empty facade and its `.d.ts`/`.d.mts`/`.d.cts` never get written. Keying on
     // the entry names gives each distinct build its own instance.
     const entriesKey = context.options.entries
-        .map((entry) => entry.name)
-        .filter(Boolean)
-        .sort()
+        .map((entry) => entry.name ?? "")
+        .filter((name) => name !== "")
+        .toSorted((a, b) => a.localeCompare(b))
         .join(",");
     const uniqueProcessId = `dts-plugin:${String(process.pid)}${context.tsconfig?.path ?? ""}:${resolveKey}:${entriesKey}`;
 

--- a/packages/packem/src/validator/package-json/validate-package-fields.ts
+++ b/packages/packem/src/validator/package-json/validate-package-fields.ts
@@ -191,14 +191,10 @@ const validateExports = (context: BuildContext<InternalBuildOptions>, exports: u
                 }
             }
 
-            // Validate mutually exclusive conditions
-            if (conditions.includes("import") && conditions.includes("require")) {
-                // This is actually valid they are mutually exclusive by nature
-            }
-
-            if (conditions.includes("development") && conditions.includes("production")) {
-                warn(context, `Conflicting conditions "development" and "production" at ${path}. These conditions are mutually exclusive`);
-            }
+            // Note: pairs like `import`/`require` and `development`/`production` are
+            // mutually exclusive at resolution time (only one ever matches), but
+            // declaring both is valid and intended — that's how a package ships
+            // separate builds per condition. So we do not warn about them here.
 
             // Recursively validate condition values
             conditions.forEach((condition) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1153,13 +1153,6 @@ importers:
         version: 6.0.3
 
   examples/mixed:
-    dependencies:
-      react:
-        specifier: ^19.2.7
-        version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/node':
         specifier: 25.9.1
@@ -1182,9 +1175,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.16
@@ -1462,9 +1452,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.16
@@ -1520,9 +1507,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.16
@@ -1712,9 +1696,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.16
@@ -1737,9 +1718,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.16
@@ -1759,9 +1737,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.16
@@ -1784,9 +1759,6 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@swc/core':
         specifier: ^1.15.40

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -777,7 +777,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@codspeed/vitest-plugin':
         specifier: ^5.5.0
-        version: 5.5.0(tinybench@2.9.0)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)
+        version: 5.5.0(tinybench@2.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)
       '@parcel/bundler-default':
         specifier: ^2.16.4
         version: 2.16.4(@parcel/core@2.16.4(@swc/helpers@0.5.23))
@@ -864,7 +864,7 @@ importers:
         version: 4.0.0-alpha.16(express@5.2.1)(hono@4.12.19)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
       babel-loader:
         specifier: ^10.1.1
         version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(cssnano@8.0.1(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -918,7 +918,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.15
-        version: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
       webpack:
         specifier: ^5.107.2
         version: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(cssnano@8.0.1(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
@@ -1951,10 +1951,10 @@ importers:
         specifier: 1.0.0-alpha.48
         version: link:../packem-share
       '@visulima/rollup-plugin-css':
-        specifier: 1.0.0-alpha.48
+        specifier: 1.0.0-alpha.49
         version: link:../rollup-plugin-css
       '@visulima/rollup-plugin-dts':
-        specifier: 1.0.0-alpha.29
+        specifier: 1.0.0-alpha.30
         version: link:../rollup-plugin-dts
       '@visulima/tsconfig':
         specifier: catalog:visulima
@@ -2117,7 +2117,7 @@ importers:
         specifier: workspace:*
         version: link:../packem-plugins
       '@visulima/packem-rollup':
-        specifier: 1.0.0-alpha.68
+        specifier: 1.0.0-alpha.69
         version: link:../packem-rollup
       '@visulima/pail':
         specifier: catalog:visulima
@@ -2607,7 +2607,7 @@ importers:
         specifier: catalog:visulima
         version: 3.0.0-alpha.10
       '@visulima/rollup-plugin-dts':
-        specifier: 1.0.0-alpha.29
+        specifier: 1.0.0-alpha.30
         version: link:../rollup-plugin-dts
       clean-css:
         specifier: catalog:style
@@ -2945,7 +2945,7 @@ importers:
     dependencies:
       react:
         specifier: '*'
-        version: 19.2.6
+        version: 19.2.7
 
   packages/rollup-plugin-css:
     dependencies:
@@ -17127,49 +17127,6 @@ packages:
   vfile@5.3.7:
     resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
 
-  vite@8.0.15:
-    resolution: {integrity: sha512-qpgllRxrLqwsMAGRdLhsEr9bepaOQk1rxH1xT2coBXLaEB/bfkqQj1j7RMxwMfnYrvO1ZnFMiwX+wBVgnsyn0g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: '>=2.8.3'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -17664,7 +17621,7 @@ snapshots:
       lint-staged: 17.0.7
       prettier: 3.8.3
       secretlint: 13.0.2
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - yaml
@@ -18652,12 +18609,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@codspeed/vitest-plugin@5.5.0(tinybench@2.9.0)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)':
+  '@codspeed/vitest-plugin@5.5.0(tinybench@2.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
       '@codspeed/core': 5.5.0
       tinybench: 2.9.0
-      vite: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - debug
 
@@ -24545,10 +24502,10 @@ snapshots:
       - smol-toml
       - yaml
 
-  '@vitejs/plugin-react@6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -24564,7 +24521,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.7)':
     dependencies:
@@ -24586,14 +24543,6 @@ snapshots:
       '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.7(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -24630,7 +24579,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -33694,7 +33643,7 @@ snapshots:
       '@vue/reactivity': 3.5.35
       obug: 2.1.1
       unplugin: 3.0.0
-      vite: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
       vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -33718,7 +33667,7 @@ snapshots:
       '@vue/reactivity': 3.5.35
       obug: 2.1.1
       unplugin: 3.0.0
-      vite: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -33896,7 +33845,7 @@ snapshots:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -33917,26 +33866,6 @@ snapshots:
       yaml: 2.8.3
     optional: true
 
-  vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.1
-      esbuild: 0.28.0
-      jiti: 2.7.0
-      less: 4.6.4
-      sass: 1.100.0
-      sass-embedded: 1.100.0
-      stylus: 0.64.0
-      sugarss: 5.0.1(postcss@8.5.15)
-      terser: 5.47.1
-      tsx: 4.22.4
-      yaml: 2.9.0
-
   vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -33956,65 +33885,6 @@ snapshots:
       terser: 5.47.1
       tsx: 4.22.4
       yaml: 2.9.0
-
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0):
-    dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
-      '@vitest/ui': 4.1.7(vitest@4.1.7)
-      happy-dom: 20.9.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
-      '@vitest/ui': 4.1.7(vitest@4.1.7)
-      happy-dom: 20.9.0
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

The `examples/` are excluded from CI (`exclude-affected-projects: "examples_*"` in `test.yml`), so they had drifted against the current packem. This PR makes **every example build cleanly** again and fixes the packem bugs the audit surfaced along the way.

I built all 29 tracked examples against current packem to find breakage. After this PR: **29/29 build with exit 0** (verified with caches cleared against a freshly built packem).

## packem fixes (5)

1. **Version-scope the build cache** (`packem`) — the persistent cache key omitted packem's own version, so an upgraded packem could serve stale resolutions from an older build. This crashed `native-node-module` with a null-byte load error (`\0packem-natives/0`) when a CommonJS dependency pulled in a `.node` addon. *(This stale-cache class also caused several phantom warnings and a spurious JSX parse error that vanished once caches were version-scoped/cleared.)*

2. **Skip virtual / query-suffixed ids in debarrel** (`packem-plugins`) — the debarrel transform read each module id from disk; Vue/Svelte SFC sub-modules carry a `?query` but can end in a source extension (`App.vue?vue&type=script&lang.ts`), so the read threw `ENOENT` and aborted the build (`vue-basic`). Now skips `\0`/`?` ids. Regression test added.

3. **Allow `development` + `production` export conditions together** (`packem`) — the validator warned that the two were "mutually exclusive". Declaring both is the intended pattern (one build per condition, only one resolves) — like the `import`/`require` pair already accepted. Removed the false positive; test updated.

4. **Infer emit formats in unbundle mode** (`packem`) — `unbundle: true` builds entries from the source tree and returns before `inferEntries` runs, so `emitESM`/`emitCJS`/`declaration` were left unset, every entry had no format, and **nothing was emitted** (`unbundle` example). Now derives formats from the same package.json signals `inferEntries` uses (respecting explicit config). Tests cover ESM-only, CJS-only, dual, no-declaration, and explicit-`emitCJS` cases.

5. **Isolate the DTS plugin per entry set across parallel environment builds** (`packem`) — per-environment/runtime declaration builds run concurrently, and `rollup-plugin-dts` is stateful. Its instance was memoized by `pid + tsconfig + resolveKey`, which differs across runtimes but **not** across environments sharing a runtime. So the default/development/production groups (all `node`) shared one instance across concurrent builds and contaminated each other — the default entry's declaration collapsed to an empty facade and `index.d.mts`/`.d.cts` were never written (`mixed`, `multi-exports`). Runtime-split packages (solid's browser/node) were unaffected. Keyed the memoization on the entry names; regression test added.

## Example updates

- Add missing `sideEffects` (`false`, or `["**/*.css"]` for the CSS examples).
- Add `types`/`typesVersions` where declarations are emitted; set `declaration: false` for the JS+CSS-only `styles`/`styles-inject` (they emit no declarations).
- Drop unused `react-dom` deps (and unused `react` in `mixed`); lockfile synced (`pnpm install --frozen-lockfile` passes).
- `types-entries`: resolve the helper import relatively (the alias didn't resolve in the DTS-only build), declare `validation.packageJson.main: false` (it's declaration-only), and fix the tsconfig `include` to cover `types/`.

(`unbundle`, `mixed`, `multi-exports`, `vue-basic`, `native-node-module` now build clean with **no** example change — pure packem fixes.)

## Verification

- All 29 buildable examples: `pnpm run build` exits 0 (caches cleared, fresh packem).
- packem tests green: `validate-package-fields` (44), `debarrel` (4), `native-modules` (4), `unbundle` (8), `package-json-exports` (54), `node-exports`+`cli` (46), `typescript` (62). No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)