### PR TITLE
chore: add multi-sample statistics and methodology docs to E2E benchmark suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,125 @@
+# Benchmarks
+
+End-to-end build benchmarks that compare `@visulima/packem` against other
+JavaScript/TypeScript bundlers (esbuild, rollup, rspack, vite, tsup, tsdown,
+bunchee, parcel, webpack, and bun) on a set of representative React projects.
+
+This suite measures **whole-build wall-clock time and output size** — the
+numbers a user actually experiences. For micro-benchmarks of individual hot
+paths inside packem's own packages, see the `__bench__/*.bench.ts` files in each
+package (Vitest `bench` + CodSpeed), which carry their own before/after
+baselines.
+
+## Running
+
+```sh
+# All builders across all projects
+pnpm --filter benchmarks test:bench
+
+# A single builder
+pnpm --filter benchmarks test:bench:packem
+
+# Filter projects (run from the benchmarks/ directory)
+jiti ./scripts/build-all.ts --project react-empty
+jiti ./scripts/build-all.ts --projects react-empty,react-mui
+
+# Control the sampling
+jiti ./scripts/build-all.ts --runs 9 --warmup 2
+```
+
+### Sampling flags
+
+| Flag        | Default | Meaning                                               |
+| ----------- | ------- | ----------------------------------------------------- |
+| `--runs`    | `5`     | Measured builds per builder (after warmup).           |
+| `--warmup`  | `1`     | Warmup builds per builder; timed but discarded.       |
+| `--project` | —       | Restrict to a single project by name.                 |
+| `--projects`| —       | Comma-separated list of projects.                     |
+
+## Methodology
+
+The design choices below exist to keep the comparison fair. They were previously
+documented only in code comments; this section consolidates them.
+
+### Multiple samples, median, reported spread
+
+Each builder runs `--warmup` discarded builds followed by `--runs` measured
+builds. The reported **Runtime** is the **median** of the measured samples, and
+the **Spread** column shows `min…max ±σ (n)`.
+
+A single timing is fragile: one GC pause, disk hiccup, or background process can
+reorder the entire leaderboard. The median resists those outliers, the warmup
+runs absorb cold-cache/JIT costs, and the spread makes the noise visible so two
+builders within each other's variance aren't read as a real difference. (See
+`summarizeSamples` in `scripts/utils.ts`.)
+
+### Cold builds
+
+Every measured run is a **cold build**: the builder's output directory is removed
+(`cleanup`) before each iteration. This models the common case (CI, a fresh
+checkout, `--no-cache`) and keeps builders that ship persistent caches from being
+credited for work they skip.
+
+As a direct consequence, **packem's persistent file cache is disabled**
+(`fileCache: false` in `builders/packem.ts`). On a cold build the cache is pure
+overhead — it writes entries to disk but never reads them back — so leaving it on
+would charge packem for cache-population I/O the other (cacheless) builders never
+pay.
+
+### Sequential execution
+
+Builders run one at a time, never via `Promise.all`. Parallel runs saturate CPU
+and I/O, inflating every builder's runtime (~10x in practice) and biasing the
+result toward whichever builder finishes first and frees capacity. Sequential
+execution gives each builder a clean resource budget.
+
+### Single output format
+
+Every builder is configured to emit a single format (ESM) so they do equivalent
+work. packem, rollup, tsup, tsdown, and bunchee can all emit multiple formats;
+restricting to one avoids penalizing the builders that would otherwise produce
+both CJS and ESM.
+
+### packem preset / backend matrix
+
+packem is benchmarked across its transformer presets and bundler backends:
+
+- **rollup backend** runs the full transformer matrix (`esbuild`, `swc`,
+  `sucrase`, `oxc`), since the transformer is a real, swappable choice there.
+- **rolldown backend** runs **once**. Rolldown transforms natively (oxc) and
+  rejects an explicit `transformer` option, so the per-transformer presets would
+  produce byte-identical output — running them as a matrix would just be
+  redundant rows.
+
+Each `(backend, preset)` pair writes to its own output directory so concurrent
+variants never clobber a shared path.
+
+## Output size
+
+For every build the suite walks the output directory and reports total original,
+gzip, and brotli size (`getFileMetrics` in `scripts/utils.ts`). Sizes are
+deterministic across runs, so they are measured once from the final build rather
+than per sample.
+
+## Known limitations
+
+- **Wall-clock only.** The E2E suite measures end-to-end time, not throughput
+  (bytes/s) or per-phase cost. For per-phase attribution use
+  `scripts/profile-packem.ts`, which taps packem internals; for normalized
+  throughput, none is reported yet.
+- **No persisted baseline.** Results are printed per run and not stored, so there
+  is no automatic run-over-run regression delta at the E2E level. Regression
+  gating currently lives in the package-level micro-benchmarks via CodSpeed.
+- **Machine-dependent absolute numbers.** Only compare builders measured in the
+  same run on the same machine; absolute milliseconds are not portable across
+  hardware or CI runners.
+- **bun** is only included when the suite is executed under the Bun runtime.
+
+## Projects
+
+| Project             | Shape                                              |
+| ------------------- | -------------------------------------------------- |
+| `react-empty`       | Minimal app — measures fixed per-build overhead.   |
+| `react-libraries`   | App pulling in common third-party libraries.       |
+| `react-mui`         | App built on Material UI (large dependency graph). |
+| `react-synthetic`   | Synthetic component tree for scaling behaviour.    |

--- a/benchmarks/scripts/build-all.ts
+++ b/benchmarks/scripts/build-all.ts
@@ -10,7 +10,7 @@ import { tsdownBuilder } from "../builders/tsdown";
 import { tsupBuilder } from "../builders/tsup";
 import { viteBuilder } from "../builders/vite";
 import { webpackBuilder } from "../builders/webpack";
-import { errorToString, getArguments, getFileMetrics } from "./utils";
+import { errorToString, getArguments, getFileMetrics, summarizeSamples } from "./utils";
 import { displayBenchmarkResults } from "./utils";
 import type { Builder, BuilderOptions } from "../builders/types";
 import { readdir } from "node:fs/promises";
@@ -19,11 +19,21 @@ interface BuilderResult {
     builderName: string;
     project: string;
     runtime: number;
+    runtimeMin: number;
+    runtimeMax: number;
+    runtimeStdDev: number;
+    samples: number;
     sourceFile: string;
     originalSize: number;
     gzipSize: number;
     brotliSize: number;
 }
+
+// Defaults: take a handful of measured samples after discarding warmup runs, so
+// a single GC pause or disk hiccup can't reorder the leaderboard. Override with
+// `--runs <n>` and `--warmup <n>`.
+const DEFAULT_RUNS = 5;
+const DEFAULT_WARMUP = 1;
 
 interface BuilderWithPreset {
     builder: Builder;
@@ -73,26 +83,51 @@ const getBuilderInstances = (): BuilderWithPreset[] => {
     return builders;
 };
 
-const runBuilder = async (builderWithPreset: BuilderWithPreset, baseOptions: BuilderOptions): Promise<BuilderResult | null> => {
+const runBuilder = async (
+    builderWithPreset: BuilderWithPreset,
+    baseOptions: BuilderOptions,
+    runs: number,
+    warmup: number,
+): Promise<BuilderResult | null> => {
     const { builder, preset, bundler } = builderWithPreset;
     const options = { ...baseOptions, preset, bundler };
     const builderName = [builder.name, bundler, preset].filter(Boolean).join("-");
 
     try {
-        await builder.cleanup?.(options);
+        const samples: number[] = [];
+        let buildPath = "";
 
-        const start = performance.now();
-        const buildPath = await builder.build(options);
-        const end = performance.now();
+        // Each iteration is an independent cold build: clean before, time the
+        // build, then move outputs. Warmup iterations prime caches/JIT and are
+        // discarded so they don't pull the median around.
+        for (let iteration = 0; iteration < warmup + runs; iteration += 1) {
+            await builder.cleanup?.(options);
 
-        await builder.move?.(options);
+            const start = performance.now();
+            buildPath = await builder.build(options);
+            const end = performance.now();
 
+            await builder.move?.(options);
+
+            if (iteration >= warmup) {
+                samples.push(end - start);
+            }
+        }
+
+        const stats = summarizeSamples(samples);
+
+        // Output is deterministic across runs, so the final build's artifacts are
+        // representative — measure size once instead of per sample.
         const { size, sizeGzip, sizeBrotli } = await getFileMetrics(buildPath);
 
         return {
             builderName,
             project: options.project,
-            runtime: end - start,
+            runtime: stats.median,
+            runtimeMin: stats.min,
+            runtimeMax: stats.max,
+            runtimeStdDev: stats.stdDev,
+            samples: stats.samples,
             sourceFile: buildPath,
             originalSize: size,
             gzipSize: sizeGzip,
@@ -113,10 +148,11 @@ const getProjects = async (): Promise<string[]> => {
     return projects.filter(project => !project.startsWith("."));
 };
 
-const runBenchmark = async (project: string): Promise<void> => {
+const runBenchmark = async (project: string, runs: number, warmup: number): Promise<void> => {
     console.log(`\n${'='.repeat(80)}`);
     console.log(`Running benchmark for project: ${project}`);
-    console.log(`Entry: ${DEFAULT_ENTRYPOINT}\n`);
+    console.log(`Entry: ${DEFAULT_ENTRYPOINT}`);
+    console.log(`Samples: ${runs} measured run(s) after ${warmup} warmup run(s) per builder\n`);
 
     const options: BuilderOptions = {
         project,
@@ -134,7 +170,7 @@ const runBenchmark = async (project: string): Promise<void> => {
     const results: (BuilderResult | null)[] = [];
 
     for (const builder of builders) {
-        results.push(await runBuilder(builder, options));
+        results.push(await runBuilder(builder, options, runs, warmup));
     }
 
     // Filter out failed builds and sort by runtime
@@ -147,7 +183,25 @@ const runBenchmark = async (project: string): Promise<void> => {
 
 (async () => {
     try {
-        const { project, projects: projectsArg } = getArguments();
+        const { project, projects: projectsArg, runs: runsArg, warmup: warmupArg } = getArguments();
+
+        // Sample counts: --runs <n> (measured) and --warmup <n> (discarded).
+        const parseCount = (value: unknown, fallback: number, label: string): number => {
+            if (value === undefined || value === true) {
+                return fallback;
+            }
+
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed < 0) {
+                throw new Error(`Invalid --${label}: ${String(value)}. Expected a non-negative integer.`);
+            }
+
+            return parsed;
+        };
+
+        const runs = Math.max(1, parseCount(runsArg, DEFAULT_RUNS, "runs"));
+        const warmup = parseCount(warmupArg, DEFAULT_WARMUP, "warmup");
 
         // Optional filter: --project <name> or --projects <a,b,c>
         const filter = [
@@ -171,7 +225,7 @@ const runBenchmark = async (project: string): Promise<void> => {
 
         // Run benchmarks for each project sequentially
         for (const project of projects) {
-            await runBenchmark(project);
+            await runBenchmark(project, runs, warmup);
         }
 
         process.exit(0);

--- a/benchmarks/scripts/utils.ts
+++ b/benchmarks/scripts/utils.ts
@@ -7,31 +7,111 @@ import { readFile, isAccessible, walk } from "@visulima/fs";
 interface BenchmarkResult {
     builderName: string;
     project?: string;
+    /** Representative runtime (median across samples) in milliseconds. */
     runtime: number;
+    /** Fastest sample in milliseconds, when more than one sample was taken. */
+    runtimeMin?: number;
+    /** Slowest sample in milliseconds, when more than one sample was taken. */
+    runtimeMax?: number;
+    /** Population standard deviation across samples in milliseconds. */
+    runtimeStdDev?: number;
+    /** Number of measured (post-warmup) samples that produced the runtime. */
+    samples?: number;
     sourceFile: string;
     originalSize: number;
     gzipSize: number;
     brotliSize: number;
 }
 
+export interface RuntimeStats {
+    /** Median of the samples — used as the representative runtime. */
+    median: number;
+    min: number;
+    max: number;
+    mean: number;
+    /** Population standard deviation. */
+    stdDev: number;
+    /** Number of samples summarized. */
+    samples: number;
+}
+
 const KEY_REGEX = /^--(.*)/;
+
+/**
+ * Summarize a set of runtime samples into robust statistics. The median is used
+ * as the representative value because it is resistant to the occasional GC pause
+ * or disk hiccup that would skew a single measurement (the previous behaviour)
+ * or a plain mean.
+ * @param samples - Measured runtimes in milliseconds (must be non-empty).
+ */
+export const summarizeSamples = (samples: number[]): RuntimeStats => {
+    if (samples.length === 0) {
+        throw new Error("summarizeSamples requires at least one sample");
+    }
+
+    const sorted = [...samples].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    const median = sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+
+    const mean = sorted.reduce((sum, value) => sum + value, 0) / sorted.length;
+    const variance = sorted.reduce((sum, value) => sum + (value - mean) ** 2, 0) / sorted.length;
+
+    return {
+        median,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+        mean,
+        stdDev: Math.sqrt(variance),
+        samples: sorted.length,
+    };
+};
 
 /**
  * Format and display benchmark results
  * @param results - Array of benchmark results to display
  */
 export const displayBenchmarkResults = (results: BenchmarkResult[]): void => {
+    const formatRuntime = (ms: number) => duration(ms, { units: ["m", "s", "ms"], round: true });
+
+    // Only show the spread column when at least one row carries multi-sample
+    // statistics, so single-run callers (e.g. getMetrics) keep the compact table.
+    const hasSpread = results.some((result) => (result.samples ?? 1) > 1);
+
+    const header = [bold("Builder"), bold("Project"), bold("Runtime (median)")];
+
+    if (hasSpread) {
+        header.push(bold("Spread (min…max ±σ)"));
+    }
+
+    header.push(bold("Source Files"), bold("Original Size"), bold("Gzip Size"), bold("Brotli Size"));
+
     const data = [
-        [bold("Builder"), bold("Project"), bold("Runtime"), bold("Source Files"), bold("Original Size"), bold("Gzip Size"), bold("Brotli Size")],
-        ...results.map((result) => [
-            cyan(result.builderName),
-            cyan(result.project || "-"),
-            yellow(duration(result.runtime, { units: ["m", "s", "ms"], round: true })),
-            green(result.sourceFile),
-            magenta(formatBytes(result.originalSize, { decimals: 2 })),
-            magenta(formatBytes(result.gzipSize, { decimals: 2 })),
-            magenta(formatBytes(result.brotliSize, { decimals: 2 })),
-        ]),
+        header,
+        ...results.map((result) => {
+            const row = [
+                cyan(result.builderName),
+                cyan(result.project || "-"),
+                yellow(formatRuntime(result.runtime)),
+            ];
+
+            if (hasSpread) {
+                const spread =
+                    (result.samples ?? 1) > 1 && result.runtimeMin !== undefined && result.runtimeMax !== undefined
+                        ? `${formatRuntime(result.runtimeMin)}…${formatRuntime(result.runtimeMax)} ±${formatRuntime(result.runtimeStdDev ?? 0)} (n=${result.samples})`
+                        : "-";
+
+                row.push(yellow(spread));
+            }
+
+            row.push(
+                green(result.sourceFile),
+                magenta(formatBytes(result.originalSize, { decimals: 2 })),
+                magenta(formatBytes(result.gzipSize, { decimals: 2 })),
+                magenta(formatBytes(result.brotliSize, { decimals: 2 })),
+            );
+
+            return row;
+        }),
     ];
 
     const config = {


### PR DESCRIPTION
## What

its allocator/hashing/LTO internals don't translate to a JS bundler benchmark. The transferable part is the *measurement methodology*: sampled timings with reported spread, and a README that documents what the numbers do and don't mean. This PR ports that to the `benchmarks/` suite. (Our package-level micro-benchmarks in `packages/*/__bench__/*.bench.ts` already have before/after baselines via CodSpeed; this targets the E2E gap.)

## Changes

- **`scripts/build-all.ts`** — previously timed each builder with a single `performance.now()` pair, so one GC pause or disk hiccup could reorder the leaderboard. Now runs `--warmup` discarded builds (default 1) followed by `--runs` measured builds (default 5) per builder. The reported **Runtime** is the **median** of the measured samples, with a new **Spread** column showing `min…max ±σ (n)`. New flags: `--runs <n>`, `--warmup <n>` (validated as non-negative integers).
- **`scripts/utils.ts`** — adds `summarizeSamples()` (median/min/max/mean/stdDev) and surfaces the spread in the results table. The spread column auto-hides for single-sample callers (e.g. `getMetrics`), so the micro-bench table is unchanged.
- **`benchmarks/README.md`** (new) — documents how to run, the sampling flags, and the methodology decisions that were buried in code comments: cold builds, `fileCache: false` for packem, sequential execution, single output format, and the packem preset/backend matrix — plus a known-limitations section.

## Usage

```sh
pnpm --filter benchmarks test:bench                 # all builders, all projects
jiti ./scripts/build-all.ts --runs 9 --warmup 2     # tune sampling
jiti ./scripts/build-all.ts --project react-empty   # filter projects
```

## Notes

- Pure benchmark-harness/tooling change — no packem runtime/product code touched.
- Not verified end-to-end in CI here (the benchmark workspace deps weren't installed in the dev environment); worth a local `pnpm --filter benchmarks test:bench --runs 3` before merge.

## Follow-ups (out of scope)

- Persisted run-over-run baseline / regression deltas at the E2E level.
- A normalized throughput metric (bytes/s).

Both are noted in the README's limitations section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCvk8uVmhaF5nyfs8rUx58