### PR TITLE
fix(rollup-plugin-dts): root each DTS program at its own entry to bound memory (#216)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,10 @@ jobs:
               uses: "anolilab/workflows/step/setup@aa162a984a4909f412bc4dbae712def066a0a681" # v20.2.5
               with:
                   node-version: "${{ matrix.node_version }}"
+                  # npm@latest (12.x) requires node ^22.22 || ^24.15 || >=26, so it refuses
+                  # to install on node 25 (EBADENGINE) and fails the whole setup step. npm 11.x
+                  # (engines `>=22.9`) supports node 25, so pin it there; other lanes keep latest.
+                  npm-version: "${{ matrix.node_version == '25' && '11' || 'latest' }}"
                   install-packages: "false"
                   install-node-gyp: "true"
 

--- a/packages/packem-plugins/eslint.config.js
+++ b/packages/packem-plugins/eslint.config.js
@@ -32,4 +32,10 @@ export default createConfig(
             "unicorn/prefer-module": "off",
         },
     },
+    {
+        files: ["__tests__/**"],
+        rules: {
+            "sonarjs/parameterized-tests": "off",
+        },
+    },
 );

--- a/packages/packem-plugins/src/plugins/debarrel.ts
+++ b/packages/packem-plugins/src/plugins/debarrel.ts
@@ -48,11 +48,11 @@ const POSSIBLE_BARREL_SPECIFIER = /(?:\.[tj]sx?|\/index\.[tj]sx?)(?:\?.*)?$/;
 const IS_EXPORT_PREFIXED = /^\s*export/;
 
 const DEFAULT_IMPORT_RE = /^(?:import|export)\s+([\w$]+)/;
-// eslint-disable-next-line sonarjs/slow-regex -- pattern is bounded by `{` or `,` separators in import specifier lists; inputs are short.
+// eslint-disable-next-line sonarjs/super-linear-regex -- pattern is bounded by `{` or `,` separators in import specifier lists; inputs are short.
 const LEADING_TRAILING_DEFAULT_RE = /([\w$]+)\s*,\s*\{|\}\s*,\s*([\w$]+)/;
 const IMPORT_NAMES_TOKENIZER_RE = /[{,]\s*(type\s+)?([\w$]+)(?:\s+as\s+([\w$]+))?/gi;
 const DEFAULT_RE_EXPORT_NAME_RE = /default\s+([a-zA-Z_$][\w$]*)(?:[;\n]|$)/;
-// eslint-disable-next-line sonarjs/slow-regex -- pattern is anchored at end of string and inputs are short import-clause slices.
+// eslint-disable-next-line sonarjs/super-linear-regex -- pattern is anchored at end of string and inputs are short import-clause slices.
 const TRAILING_AS_ALIAS_RE = /([\w$]+)\s*as\s*$/;
 const WILDCARD_EXPORT_RE = /^export\s+\*(?!\s+as)/;
 const AS_KEYWORD_RE = /\bas\b/;

--- a/packages/packem-plugins/src/plugins/detect-duplicated/utils/get-package-info.ts
+++ b/packages/packem-plugins/src/plugins/detect-duplicated/utils/get-package-info.ts
@@ -11,7 +11,7 @@ export interface PackageInfo {
     version: string;
 }
 
-// eslint-disable-next-line import/exports-last, sonarjs/slow-regex -- consumed below; inputs are resolved filesystem ids of bounded length, not user-controlled DoS vectors.
+// eslint-disable-next-line import/exports-last, sonarjs/super-linear-regex -- consumed below; inputs are resolved filesystem ids of bounded length, not user-controlled DoS vectors.
 export const packagePathRegex = /.*\/node_modules\/(?:@[^/]+\/)?[^/]+/;
 
 /**

--- a/packages/packem-plugins/src/plugins/fix-dts-default-cjs-exports-util.ts
+++ b/packages/packem-plugins/src/plugins/fix-dts-default-cjs-exports-util.ts
@@ -8,9 +8,9 @@ import type { LoggingFunction, SourceMapInput } from "rollup";
 
 const DIRECT_DEFAULT_RE = /^export\s+default\s+(\w+);/m;
 const EXPORT_BRACES_RE = /export\s*\{([^}]*)\}/;
-// eslint-disable-next-line sonarjs/slow-regex -- short export specifier strings
+// eslint-disable-next-line sonarjs/super-linear-regex -- short export specifier strings
 const AS_DEFAULT_RE = /\s*as\s+default\s*/;
-// eslint-disable-next-line sonarjs/slow-regex -- bounded whitespace prior to a literal `}`
+// eslint-disable-next-line sonarjs/super-linear-regex -- bounded whitespace prior to a literal `}`
 const TRIM_TRAILING_BRACE_RE = /\s+\}$/;
 const TRAILING_SEMI_RE = /;$/;
 const MULTI_NEWLINE_RE = /(?:\r?\n\s*){2,}/g;

--- a/packages/packem-plugins/src/plugins/minify-html-literals/lib/strategy.ts
+++ b/packages/packem-plugins/src/plugins/minify-html-literals/lib/strategy.ts
@@ -52,7 +52,7 @@ const optimizationLevelFrom = (level: CleanCSS.Options["level"]): OptimizationLe
     return level as unknown as OptimizationLevels;
 };
 
-// eslint-disable-next-line sonarjs/slow-regex -- bounded character class with no overlapping quantifiers; input is css from clean-css output, not user controlled
+// eslint-disable-next-line sonarjs/super-linear-regex -- bounded character class with no overlapping quantifiers; input is css from clean-css output, not user controlled
 const PSEUDO_CLASS_WITH_ARGS_RE = /(:[^()\s]+\(([^()]*)\))\s*\{/g;
 const WHITESPACE_RE = /\s/g;
 const HAS_WHITESPACE_RE = /\s/;
@@ -159,8 +159,8 @@ export const defaultMinifyOptions: HTMLOptions = {
     minifyJS: true,
     removeAttributeQuotes: false,
     removeComments: true,
-    removeEmptyAttributes: true,
     removeDefaultTypeAttributes: true,
+    removeEmptyAttributes: true,
     useShortDoctype: true,
 };
 

--- a/packages/packem-plugins/src/plugins/require-cjs-transformer.ts
+++ b/packages/packem-plugins/src/plugins/require-cjs-transformer.ts
@@ -51,6 +51,7 @@ const REGEX_PATTERNS = {
     // (`= createRequire(import.meta.url);`) so that when a chunk inlines an older packem-built dep
     // whose dist still ships the eager declaration, the prepended lazy copy (kept as the first
     // match) survives and the eager duplicate is removed instead of throwing at boot.
+    // eslint-disable-next-line sonarjs/regex-complexity -- the pattern is intentionally explicit; simplifying it would change matching behavior
     require: /const\s+__cjs_require\s*=\s*(?:(?:__cjs_)?createRequire(?:\$\w+)?\s*\([^)]*\)|\([^)]*\)\s*=>\s*\{[\s\S]*?\})\s*;\s*/g,
 } as const;
 

--- a/packages/packem-plugins/src/plugins/url.ts
+++ b/packages/packem-plugins/src/plugins/url.ts
@@ -159,7 +159,6 @@ export const urlPlugin = ({
             if ((limit && stats.size > limit) || limit === 0) {
                 // sha1 is intentional here: this hash is a CONTENT FINGERPRINT for cache busting,
                 // not a cryptographic signature; collisions on asset contents are not a security concern.
-                // eslint-disable-next-line sonarjs/hashing -- non-security content fingerprint
                 const hash = crypto.createHash("sha1").update(buffer).digest("hex").slice(0, 16);
                 const extension = extname(id);
                 const name = basename(id, extension);

--- a/packages/packem-rollup/eslint.config.js
+++ b/packages/packem-rollup/eslint.config.js
@@ -39,4 +39,11 @@ export default createConfig(
             "vitest/require-mock-type-parameters": "off",
         },
     },
+    {
+        files: ["__tests__/**"],
+        rules: {
+            // These simple test suites read clearer as individual cases than parameterized ones.
+            "sonarjs/parameterized-tests": "off",
+        },
+    },
 );

--- a/packages/packem-rollup/src/types.ts
+++ b/packages/packem-rollup/src/types.ts
@@ -119,12 +119,12 @@ export interface PackemRollupOptions {
     sourcemap?: SourcemapsPluginOptions;
     sucrase?: SucrasePluginConfig | false;
     swc?: SwcPluginConfig | false;
-    treeshake?: RollupOptions["treeshake"];
+    treeshake?: NonNullable<RollupOptions["treeshake"]>;
     tsconfigPaths?: TsconfigPathsPluginOptions | false;
     url?: UrlOptions | false;
     visualizer?: PluginVisualizerOptions | false;
     wasm?: RollupWasmOptions | false;
-    watch?: RollupOptions["watch"];
+    watch?: NonNullable<RollupOptions["watch"]>;
 }
 
 export type RollupPlugins = {

--- a/packages/packem-share/eslint.config.js
+++ b/packages/packem-share/eslint.config.js
@@ -31,4 +31,10 @@ export default createConfig(
             "unicorn/prefer-module": "off",
         },
     },
+    {
+        files: ["__tests__/**"],
+        rules: {
+            "sonarjs/parameterized-tests": "off",
+        },
+    },
 );

--- a/packages/packem-share/src/utils/svg-encoder.ts
+++ b/packages/packem-share/src/utils/svg-encoder.ts
@@ -13,7 +13,7 @@ const svgEncoder = (buffer: Buffer): string => {
     svgString = stripSvgComments(svgString);
     // Safe regex that matches only the exact 'class' attribute without backtracking
     // Uses word boundaries and explicit character sets to avoid ReDoS
-    // eslint-disable-next-line sonarjs/slow-regex
+    // eslint-disable-next-line sonarjs/super-linear-regex
     svgString = svgString.replaceAll(/\s*\bclass\s*=\s*(?:"[^"]*"|'[^']*')/gi, "");
     // Normalize all whitespace (newlines, tabs, runs of spaces) in a single pass,
     // then trim. Folding the previous separate `\s{2,}` / `[\n\r\t]` / `\s{2,}`

--- a/packages/packem/src/bundler/get-build-options.ts
+++ b/packages/packem/src/bundler/get-build-options.ts
@@ -369,7 +369,10 @@ export const createJsBuildOptions = async (context: BuildContext<InternalBuildOp
                     include: context.options.rollup.babel.include ?? BABEL_DEFAULT_INCLUDE_REGEX,
                     ...context.options.rollup.babel,
                     root: context.options.rootDir,
-                    sourceMaps: context.options.rollup.babel.sourceMaps ?? context.options.sourcemap,
+                    // `sourceMaps` is not part of Babel 8's `InputOptions` type (so the property
+                    // access is otherwise an `any`/error type); cast to the concrete shape to read
+                    // it type-safely while preserving the runtime fallback to the build sourcemap.
+                    sourceMaps: (context.options.rollup.babel as { sourceMaps?: boolean | "both" | "inline" }).sourceMaps ?? context.options.sourcemap,
                 }),
                 fileCache,
             ),

--- a/packages/packem/src/config/preset/auto.ts
+++ b/packages/packem/src/config/preset/auto.ts
@@ -9,7 +9,7 @@ import type { BuildConfig, InternalBuildOptions } from "../../types";
 import inferEntries from "./utils/infer-entries";
 import overwriteWithPublishConfig from "./utils/overwrite-with-publish-config";
 
-// eslint-disable-next-line sonarjs/slow-regex -- bounded path segment match against collected file list
+// eslint-disable-next-line sonarjs/super-linear-regex -- simple `/dist/` path match; the `.*` segments are intentional and not a ReDoS risk on file paths
 const DIST_PATH_REGEXP = /.*\/dist\/.*/;
 
 const TRAILING_SLASH_REGEXP = /\/$/;

--- a/packages/packem/src/config/preset/preact.ts
+++ b/packages/packem/src/config/preset/preact.ts
@@ -140,12 +140,12 @@ export interface PreactPresetOptions {
     /**
      * Custom Babel plugins to add
      */
-    plugins?: BabelPluginConfig["plugins"];
+    plugins?: NonNullable<BabelPluginConfig["plugins"]>;
 
     /**
      * Custom Babel presets to add
      */
-    presets?: BabelPluginConfig["presets"];
+    presets?: NonNullable<BabelPluginConfig["presets"]>;
 }
 
 export const createPreactPreset = (options: PreactPresetOptions = {}): BuildConfig => {
@@ -177,15 +177,16 @@ export const createPreactPreset = (options: PreactPresetOptions = {}): BuildConf
                 const isProduction = context.environment === "production";
 
                 if (babelConfig && typeof babelConfig === "object" && babelConfig.presets) {
-                    const presetIndex = babelConfig.presets.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
+                    const presetList = babelConfig.presets as NonNullable<BabelPluginConfig["presets"]>;
+                    const presetIndex = presetList.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
 
                     if (presetIndex !== -1) {
-                        const preset = babelConfig.presets[presetIndex] as [string, Record<string, unknown>];
+                        const preset = presetList[presetIndex] as [string, Record<string, unknown>];
 
-                        babelConfig.presets[presetIndex] = [
+                        presetList[presetIndex] = [
                             preset[0],
                             {
-                                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison -- `typeof x === "object"` is also true for null, so the explicit null check is a real runtime guard; relaxed strictNullChecks hides the union from the type checker.
+                                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `typeof x === "object"` is also true for null, so the explicit null check is a real runtime guard; relaxed strictNullChecks hides the union from the type checker.
                                 ...typeof preset[1] === "object" && preset[1] !== null ? preset[1] : {},
                                 development: !isProduction,
                             },

--- a/packages/packem/src/config/preset/preact.ts
+++ b/packages/packem/src/config/preset/preact.ts
@@ -177,13 +177,12 @@ export const createPreactPreset = (options: PreactPresetOptions = {}): BuildConf
                 const isProduction = context.environment === "production";
 
                 if (babelConfig && typeof babelConfig === "object" && babelConfig.presets) {
-                    const presetList = babelConfig.presets as NonNullable<BabelPluginConfig["presets"]>;
-                    const presetIndex = presetList.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
+                    const presetIndex = babelConfig.presets.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
 
                     if (presetIndex !== -1) {
-                        const preset = presetList[presetIndex] as [string, Record<string, unknown>];
+                        const preset = babelConfig.presets[presetIndex] as [string, Record<string, unknown>];
 
-                        presetList[presetIndex] = [
+                        babelConfig.presets[presetIndex] = [
                             preset[0],
                             {
                                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `typeof x === "object"` is also true for null, so the explicit null check is a real runtime guard; relaxed strictNullChecks hides the union from the type checker.

--- a/packages/packem/src/config/preset/react.ts
+++ b/packages/packem/src/config/preset/react.ts
@@ -26,12 +26,12 @@ export interface ReactPresetOptions {
     /**
      * Custom Babel plugins to add
      */
-    plugins?: BabelPluginConfig["plugins"];
+    plugins?: NonNullable<BabelPluginConfig["plugins"]>;
 
     /**
      * Custom Babel presets to add
      */
-    presets?: BabelPluginConfig["presets"];
+    presets?: NonNullable<BabelPluginConfig["presets"]>;
 }
 
 /**
@@ -98,15 +98,16 @@ export const createReactPreset = (options: ReactPresetOptions = {}): BuildConfig
                 const babelConfig = context.options.rollup.babel;
 
                 if (babelConfig && typeof babelConfig === "object" && babelConfig.presets) {
-                    const presetIndex = babelConfig.presets.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
+                    const presetList = babelConfig.presets as NonNullable<BabelPluginConfig["presets"]>;
+                    const presetIndex = presetList.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
 
                     if (presetIndex !== -1) {
-                        const preset = babelConfig.presets[presetIndex] as [string, Record<string, unknown>];
+                        const preset = presetList[presetIndex] as [string, Record<string, unknown>];
 
-                        babelConfig.presets[presetIndex] = [
+                        presetList[presetIndex] = [
                             preset[0],
                             {
-                                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison -- `typeof x === "object"` is also true for null, so the explicit null check is a real runtime guard; relaxed strictNullChecks hides the union from the type checker.
+                                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `typeof x === "object"` is also true for null, so the explicit null check is a real runtime guard; relaxed strictNullChecks hides the union from the type checker.
                                 ...typeof preset[1] === "object" && preset[1] !== null ? preset[1] : {},
                                 development: context.environment === "development",
                             },

--- a/packages/packem/src/config/preset/react.ts
+++ b/packages/packem/src/config/preset/react.ts
@@ -98,13 +98,12 @@ export const createReactPreset = (options: ReactPresetOptions = {}): BuildConfig
                 const babelConfig = context.options.rollup.babel;
 
                 if (babelConfig && typeof babelConfig === "object" && babelConfig.presets) {
-                    const presetList = babelConfig.presets as NonNullable<BabelPluginConfig["presets"]>;
-                    const presetIndex = presetList.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
+                    const presetIndex = babelConfig.presets.findIndex((preset) => Array.isArray(preset) && preset[0] === "@babel/preset-react");
 
                     if (presetIndex !== -1) {
-                        const preset = presetList[presetIndex] as [string, Record<string, unknown>];
+                        const preset = babelConfig.presets[presetIndex] as [string, Record<string, unknown>];
 
-                        presetList[presetIndex] = [
+                        babelConfig.presets[presetIndex] = [
                             preset[0],
                             {
                                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `typeof x === "object"` is also true for null, so the explicit null check is a real runtime guard; relaxed strictNullChecks hides the union from the type checker.

--- a/packages/packem/src/config/preset/solid.ts
+++ b/packages/packem/src/config/preset/solid.ts
@@ -72,12 +72,12 @@ export interface SolidPresetOptions {
     /**
      * Custom Babel plugins to add
      */
-    plugins?: BabelPluginConfig["plugins"];
+    plugins?: NonNullable<BabelPluginConfig["plugins"]>;
 
     /**
      * Custom Babel presets to add
      */
-    presets?: BabelPluginConfig["presets"];
+    presets?: NonNullable<BabelPluginConfig["presets"]>;
 
     /**
      * SolidJS-specific options for babel-preset-solid

--- a/packages/packem/src/config/preset/utils/infer-entries.ts
+++ b/packages/packem/src/config/preset/utils/infer-entries.ts
@@ -35,7 +35,8 @@ const LEADING_SLASH_REGEXP = /^\//;
 const LEADING_DOT_SLASH_REGEXP = /^\.\//;
 const TRAILING_SLASH_REGEXP = /\/$/;
 const WORD_EXTENSION_REGEXP = /\.\w+$/;
-// eslint-disable-next-line sonarjs/slow-regex -- trailing wildcard strip on short export path segments
+
+// eslint-disable-next-line sonarjs/super-linear-regex -- trailing glob-tail match on short entry patterns; not a ReDoS risk
 const GLOB_TAIL_REGEXP = /\*.*$/;
 const TS_SOURCE_REGEXP = /\.(?:tsx?|cts|mts)$/;
 const TS_LIKE_REGEXP = /\.[cm]?tsx?$/;

--- a/packages/packem/src/rolldown/get-rolldown-options.ts
+++ b/packages/packem/src/rolldown/get-rolldown-options.ts
@@ -43,12 +43,15 @@ const REGION_MARKER_RE = /^\s*\/\/#(?:end)?region\b/;
 const LEADING_WHITESPACE_RE = /^\s+/;
 const CJS_MJS_RE = /\.[cm]js$/;
 
+/* eslint-disable no-secrets/no-secrets -- the doc comment below references internal function names, which the entropy heuristic flags as secrets */
+
 /**
  * Return a shallow copy of `object` without the given keys. Used to drop the
  * rollup-only option keys that rolldown 1.1.5's stricter schema rejects (see the
  * key lists in `getRolldownTransformOptions` / `getRolldownOptions`).
  */
-const omit = (object: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> => {
+/* eslint-enable no-secrets/no-secrets */
+const omit = (object: Record<string, unknown>, keys: ReadonlyArray<string>): Record<string, unknown> => {
     const result: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(object)) {
@@ -149,7 +152,7 @@ export const getRolldownOptions = async (context: BuildContext<InternalBuildOpti
     // Strip the rollup-only keys rolldown 1.1.5 rejects (see ROLLDOWN_UNSUPPORTED_* above) so the
     // rolldown backend builds without "Invalid options" warnings.
     if (options.treeshake && typeof options.treeshake === "object") {
-        options.treeshake = omit(options.treeshake as Record<string, unknown>, ["preset"]) as typeof options.treeshake;
+        options.treeshake = omit(options.treeshake as Record<string, unknown>, ["preset"]);
     }
 
     if (Array.isArray(options.output)) {
@@ -175,7 +178,7 @@ export const getRolldownOptions = async (context: BuildContext<InternalBuildOpti
                 sanitized.minify = true;
             }
 
-            return sanitized as OutputOptions;
+            return sanitized;
         });
     }
 

--- a/packages/packem/src/rollup/get-rollup-options.ts
+++ b/packages/packem/src/rollup/get-rollup-options.ts
@@ -521,7 +521,7 @@ export const buildInputMap = (context: BuildContext<InternalBuildOptions>): Reco
         const { name } = entry;
         const resolved = resolve(context.options.rootDir, entry.input);
 
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison -- Record index type lies without noUncheckedIndexedAccess; input[name] is undefined at runtime for not-yet-seen names
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index type lies without noUncheckedIndexedAccess; input[name] is undefined at runtime for not-yet-seen names
         if (input[name] !== undefined && input[name] !== resolved) {
             throw new Error(
                 `Duplicate rollup input name "${name}" — one maps to "${input[name]}", another to "${resolved}". Each entry must have a unique name.`,
@@ -556,8 +556,16 @@ const formatRollupLog = (log: RollupLog): string => {
 //                      without breaking CJS interop. Suppressing it conditionally (on cjsInterop) or
 //                      surfacing it under `--debug` were both tried and rejected by the suite, which
 //                      asserts clean stderr for cjsInterop-disabled and `--debug` builds alike.
+//   • PLUGIN_TIMINGS — a rolldown-only performance advisory ("your build spent significant time in
+//                      plugin X"). It fires non-deterministically based on wall-clock time, so it
+//                      only appears when the machine is under load (e.g. a busy CI runner) and is
+//                      absent on the rollup lane entirely. Because pail routes warnings to stderr,
+//                      it randomly broke the integration suite's `stderr === ""` assertions. It is a
+//                      timing hint, not an actionable defect (dts generation is inherently slow), so
+//                      it is dropped to keep stderr deterministic.
 // eslint-disable-next-line import/exports-last -- consumed by the rolldown options builder's onLog
-export const isSuppressedBundlerLogCode = (code: string | undefined): boolean => code === "EMPTY_BUNDLE" || code === "MIXED_EXPORTS";
+export const isSuppressedBundlerLogCode = (code: string | undefined): boolean =>
+    code === "EMPTY_BUNDLE" || code === "MIXED_EXPORTS" || code === "PLUGIN_TIMINGS";
 
 const handleRollupLog = (context: BuildContext<InternalBuildOptions>, type: "build" | "dts", level: "debug" | "info" | "warn", log: RollupLog): void => {
     if (isSuppressedBundlerLogCode(log.code)) {

--- a/packages/rollup-plugin-css/src/types.ts
+++ b/packages/rollup-plugin-css/src/types.ts
@@ -135,7 +135,7 @@ export interface PostCSSOptions {
      * Set PostCSS parser, e.g. `sugarss`.
      * Overrides the one loaded from PostCSS config file, if any.
      */
-    parser?: PostCSSConfig["parser"] | string;
+    parser?: NonNullable<PostCSSConfig["parser"]> | string;
 
     /**
      * A list of plugins for PostCSS,
@@ -149,16 +149,16 @@ export interface PostCSSOptions {
      * Set PostCSS stringifier.
      * Overrides the one loaded from PostCSS config file, if any.
      */
-    stringifier?: PostCSSConfig["stringifier"] | string;
+    stringifier?: NonNullable<PostCSSConfig["stringifier"]> | string;
 
     /**
      * Set PostCSS syntax.
      * Overrides the one loaded from PostCSS config file, if any.
      */
-    syntax?: PostCSSConfig["syntax"] | string;
+    syntax?: NonNullable<PostCSSConfig["syntax"]> | string;
 
     /** `to` option for PostCSS, required for some plugins. */
-    to?: PostCSSConfig["to"];
+    to?: NonNullable<PostCSSConfig["to"]>;
 
     /**
      * Enable/disable or pass options for CSS URL resolver.

--- a/packages/rollup-plugin-css/src/utils/generate-js-exports.ts
+++ b/packages/rollup-plugin-css/src/utils/generate-js-exports.ts
@@ -121,7 +121,7 @@ interface AppendModulesDtsOptions {
     cssVariableName: string;
     defaultExport: string;
     dtsOutput: string[];
-    inject?: JsExportOptions["inject"];
+    inject?: NonNullable<JsExportOptions["inject"]>;
     modulesExports: Record<string, string>;
     modulesVariableName: string;
     supportModules: boolean;
@@ -230,7 +230,7 @@ interface AppendClassExportsOptions {
     dts?: boolean;
     dtsOutput: string[];
     id: string;
-    logger?: JsExportOptions["logger"];
+    logger?: NonNullable<JsExportOptions["logger"]>;
     modulesExports: Record<string, string>;
     namedExports?: boolean | ((name: string) => string);
     output: string[];
@@ -280,7 +280,7 @@ interface GenerateInlineExportsParameters {
     dts?: boolean;
     dtsOutput: string[];
     id: string;
-    logger?: JsExportOptions["logger"];
+    logger?: NonNullable<JsExportOptions["logger"]>;
     modulesExports: Record<string, string>;
     modulesVariableName: string;
     namedExports?: boolean | ((name: string) => string);

--- a/packages/rollup-plugin-css/src/utils/sourcemap.ts
+++ b/packages/rollup-plugin-css/src/utils/sourcemap.ts
@@ -7,7 +7,7 @@ import { DATA_URI_REGEXP } from "../loaders/postcss/constants";
 
 // The capturing group is consumed by `getMap` below via a `.source`-cloned regex,
 // which the regexp plugin cannot trace, so no-unused-capturing-group is a false positive.
-// eslint-disable-next-line regexp/no-misleading-capturing-group, regexp/no-super-linear-backtracking, regexp/no-unused-capturing-group, sonarjs/slow-regex
+// eslint-disable-next-line regexp/no-misleading-capturing-group, regexp/no-super-linear-backtracking, regexp/no-unused-capturing-group, sonarjs/super-linear-regex
 const mapBlockRe = /(?:\n|\r\n)?\/\*[#*@]+\s*sourceMappingURL\s*=\s*(\S+)\s*\*+\//g;
 // eslint-disable-next-line regexp/no-unused-capturing-group -- group consumed via the `.source`-cloned regex in getMap
 const mapLineRe = /(?:\n|\r\n)?\/\/[#@]+\s*sourceMappingURL\s*=\s*(\S+)\s*/g;

--- a/packages/rollup-plugin-dts/__tests__/many-entry.test.ts
+++ b/packages/rollup-plugin-dts/__tests__/many-entry.test.ts
@@ -1,0 +1,80 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { rollup } from "rollup";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { dts } from "../src/index.js";
+import { MAX_RETAINED_PROGRAMS } from "../src/tsc/emit-compiler.js";
+import { globalContext } from "../src/tsc/context.js";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const temporaryDirectory = path.join(dirname, "temp/many-entry");
+
+// Regression for visulima/packem#216: the tsc DTS path used to root one shared program at *every*
+// build entry and full-type-check the union at once, so memory scaled with total entry count and
+// OOM'd on many-entry packages. The fix roots each program at only its own module. This test guards
+// the functional side of that change — every entry must still receive a correct, non-empty
+// declaration — across more entries than the per-entry program cache retains (MAX_RETAINED_PROGRAMS),
+// so the cache evicts and rebuilds mid-build.
+describe("many-entry dts (packem#216)", () => {
+    beforeAll(async () => {
+        await rm(temporaryDirectory, { force: true, recursive: true });
+        await mkdir(temporaryDirectory, { recursive: true });
+        await writeFile(
+            path.join(temporaryDirectory, "tsconfig.json"),
+            JSON.stringify({ compilerOptions: { module: "ESNext", moduleResolution: "Bundler", strict: true, target: "ESNext" } }),
+        );
+    });
+
+    afterAll(async () => {
+        await rm(temporaryDirectory, { force: true, recursive: true });
+    });
+
+    it("emits a correct declaration for every entry when a build has many independent entries", async () => {
+        expect.hasAssertions();
+
+        // Default options use `globalContext` (newContext is false), so reset it for an isolated
+        // program-count assertion below.
+        globalContext.programs.length = 0;
+
+        const entryCount = 12;
+        const input: Record<string, string> = {};
+
+        for (let index = 0; index < entryCount; index++) {
+            const file = path.join(temporaryDirectory, `entry${index}.ts`);
+
+            await writeFile(
+                file,
+                `export interface Entry${index} { readonly tag: "entry-${index}"; readonly value: number; }\nexport declare const entry${index}: Entry${index};\n`,
+            );
+
+            input[`entry${index}`] = file;
+        }
+
+        const bundle = await rollup({
+            input,
+            plugins: [dts({ emitDtsOnly: true, oxc: false, tsconfig: path.join(temporaryDirectory, "tsconfig.json") })],
+        });
+
+        const { output } = await bundle.generate({ format: "es" });
+
+        await bundle.close();
+
+        const chunks = output.filter((item): item is Extract<typeof item, { type: "chunk" }> => item.type === "chunk");
+
+        for (let index = 0; index < entryCount; index++) {
+            const chunk = chunks.find((candidate) => candidate.code.includes(`interface Entry${index}`));
+
+            expect(chunk, `entry${index} declaration should be emitted`).toBeDefined();
+            expect(chunk?.code).toContain(`tag: "entry-${index}"`);
+        }
+
+        // The fix roots each program at one entry, so independent entries produce multiple programs
+        // (a revert to the shared all-entries program would leave exactly 1), and retention is
+        // capped (a revert of the eviction would leave one per entry, i.e. `entryCount`).
+        expect(globalContext.programs.length).toBeGreaterThan(1);
+        expect(globalContext.programs.length).toBeLessThanOrEqual(MAX_RETAINED_PROGRAMS);
+    });
+});

--- a/packages/rollup-plugin-dts/__tests__/many-entry.test.ts
+++ b/packages/rollup-plugin-dts/__tests__/many-entry.test.ts
@@ -30,8 +30,11 @@ describe("many-entry dts (packem#216)", () => {
 
     afterAll(async () => {
         await rm(temporaryDirectory, { force: true, recursive: true });
-    });
+    }, 30_000);
 
+    // Each entry roots its own tsc program, so this deliberately builds more programs than most
+    // tests. Under v8 coverage instrumentation on a loaded CI runner that comfortably exceeds the
+    // default 30s test timeout, so give it a generous explicit budget.
     it("emits a correct declaration for every entry when a build has many independent entries", async () => {
         expect.hasAssertions();
 
@@ -76,5 +79,5 @@ describe("many-entry dts (packem#216)", () => {
         // capped (a revert of the eviction would leave one per entry, i.e. `entryCount`).
         expect(globalContext.programs.length).toBeGreaterThan(1);
         expect(globalContext.programs.length).toBeLessThanOrEqual(MAX_RETAINED_PROGRAMS);
-    });
+    }, 120_000);
 });

--- a/packages/rollup-plugin-dts/src/options.ts
+++ b/packages/rollup-plugin-dts/src/options.ts
@@ -111,7 +111,7 @@ export interface GeneralOptions {
      *
      * Accepts minimatch glob patterns, regular expressions, or arrays of either.
      */
-    exclude?: FilterPattern;
+    exclude?: Exclude<FilterPattern, undefined>;
 
     /**
      * The generator used to produce `.d.ts` files.
@@ -137,7 +137,7 @@ export interface GeneralOptions {
      * By default, all TypeScript and Vue files are included.
      * Accepts minimatch glob patterns, regular expressions, or arrays of either.
      */
-    include?: FilterPattern;
+    include?: Exclude<FilterPattern, undefined>;
 
     /**
      * Logger used for user-facing diagnostics (experimental-feature warnings, the compiler
@@ -390,7 +390,7 @@ const readTsconfigFile = (p: string): string | undefined => {
             // The classic compiler's `ts.sys.readFile` strips a leading UTF-8 BOM before
             // handing the text to `ts.readConfigFile`; `readFileSync` does not. Strip it here
             // so a BOM-prefixed tsconfig parses identically under both compilers.
-            return content.charCodeAt(0) === 0xFE_FF ? content.slice(1) : content;
+            return content.codePointAt(0) === 0xFE_FF ? content.slice(1) : content;
         } catch {
             return undefined;
         }

--- a/packages/rollup-plugin-dts/src/reexport-specifier.ts
+++ b/packages/rollup-plugin-dts/src/reexport-specifier.ts
@@ -35,9 +35,9 @@ const RE_INLINE_IMPORT = /\bimport\(\s*["']([^"']+)["']\s*\)\.(\w+)/g;
 // quote; greedy `[^'"]*` cannot cross a quote, so the match is bounded and the
 // pattern has no overlapping quantifiers (no super-linear backtracking).
 const RE_IMPORT_STATEMENT = /\bimport\b([^'"]*)["']([^"']+)["']/g;
-// eslint-disable-next-line sonarjs/slow-regex -- `[^}]*` is bounded by the closing brace; linear, no backtracking
+// eslint-disable-next-line sonarjs/super-linear-regex -- `[^}]*` is bounded by the closing brace; linear, no backtracking
 const RE_BRACED = /\{([^}]*)\}/;
-// eslint-disable-next-line sonarjs/slow-regex -- two `\s+` separated by the literal `as`; no overlapping quantifiers
+// eslint-disable-next-line sonarjs/super-linear-regex -- two `\s+` separated by the literal `as`; no overlapping quantifiers
 const RE_AS = /\s+as\s+/;
 const RE_TYPE_PREFIX = /^type\s+/;
 // `export * from "X"` (but not `export * as ns from "X"`, which only exposes a namespace).

--- a/packages/rollup-plugin-dts/src/tsc/emit-compiler.ts
+++ b/packages/rollup-plugin-dts/src/tsc/emit-compiler.ts
@@ -26,13 +26,12 @@ const defaultCompilerOptions: ts.CompilerOptions = {
 
 const createTsProgramFromParsedConfig = ({
     baseDirectory,
-    entries,
     fsSystem,
     id,
     parsedConfig,
     tsMacro,
     vue,
-}: Pick<TscOptions, "entries" | "vue" | "tsMacro" | "id"> & {
+}: Pick<TscOptions, "vue" | "tsMacro" | "id"> & {
     baseDirectory: string;
     fsSystem: ts.System;
     parsedConfig: ts.ParsedCommandLine;
@@ -60,7 +59,12 @@ const createTsProgramFromParsedConfig = ({
         ...vue || tsMacro ? { allowNonTsExtensions: true } : undefined,
     };
 
-    const rootNames = [...new Set([id, ...entries ?? parsedConfig.fileNames].map((f) => fsSystem.resolvePath(f)))];
+    // Root the program at only this module. TypeScript still pulls in everything `id`
+    // transitively imports, which is all that emitting `id`'s declaration requires. Rooting at
+    // every build entry (the previous `[id, ...entries]`) made one shared program full-type-check
+    // the union of all entries at once, so peak memory scaled with total entry count and OOM'd on
+    // many-entry packages (visulima/packem#216).
+    const rootNames = [fsSystem.resolvePath(id)];
 
     const host = ts.createCompilerHost(compilerOptions, true);
 
@@ -102,7 +106,7 @@ const createTsProgramFromParsedConfig = ({
     };
 };
 
-const createTsProgram = ({ context = globalContext, cwd, entries, id, tsconfig, tsconfigRaw, tsMacro, vue }: TscOptions): TscModule => {
+const createTsProgram = ({ context = globalContext, cwd, id, tsconfig, tsconfigRaw, tsMacro, vue }: TscOptions): TscModule => {
     const fsSystem = createFsSystem(context.files);
     const baseDirectory = tsconfig ? dirname(tsconfig) : cwd;
     const parsedConfig = ts.parseJsonConfigFileContent(tsconfigRaw, fsSystem, baseDirectory);
@@ -111,7 +115,6 @@ const createTsProgram = ({ context = globalContext, cwd, entries, id, tsconfig, 
 
     return createTsProgramFromParsedConfig({
         baseDirectory,
-        entries,
         fsSystem,
         id,
         parsedConfig,
@@ -120,39 +123,27 @@ const createTsProgram = ({ context = globalContext, cwd, entries, id, tsconfig, 
     });
 };
 
-// Cache the set of root file names per program so membership checks during program
-// lookup are O(1) instead of re-allocating the roots array and doing an O(roots) scan
-// per candidate, per module load.
-const programRootsCache = new WeakMap<ts.Program, Set<string>>();
-
-const getProgramRoots = (program: ts.Program): Set<string> => {
-    let roots = programRootsCache.get(program);
-
-    if (!roots) {
-        roots = new Set(program.getRootFileNames());
-        programRootsCache.set(program, roots);
-    }
-
-    return roots;
-};
+// Cap on retained programs. Rooting each program at a single module (see
+// `createTsProgramFromParsedConfig`) keeps peak memory proportional to a few entry closures
+// rather than the whole entry set, but retaining one program per entry would still accumulate on a
+// package with dozens of independent entries — each program holds its own copy of the default
+// library. Evict the oldest beyond this window; a later module that needed an evicted program
+// simply rebuilds it (correct, only recomputed). Exported for the many-entry regression test.
+// eslint-disable-next-line import/exports-last -- co-located with the retention logic it caps
+export const MAX_RETAINED_PROGRAMS = 8;
 
 const createOrGetTsModule = (options: TscOptions): TscModule => {
-    const { context = globalContext, entries, id } = options;
-    const existingProgram = context.programs.find((candidate) => {
-        const roots = getProgramRoots(candidate);
+    const { context = globalContext, id } = options;
 
-        if (entries) {
-            return entries.every((entry) => roots.has(entry));
-        }
-
-        return roots.has(id);
-    });
-
-    if (existingProgram) {
-        const sourceFile = existingProgram.getSourceFile(id);
+    // Reuse any retained program that already contains `id` as a source file — whether `id` is
+    // that program's own root or a module pulled into a sibling entry's import closure. This
+    // recovers cross-entry sharing without rooting every program at all entries (which made one
+    // shared program full-type-check the whole entry set and OOM on many-entry packages, #216).
+    for (const candidate of context.programs) {
+        const sourceFile = candidate.getSourceFile(id);
 
         if (sourceFile) {
-            return { file: sourceFile, program: existingProgram };
+            return { file: sourceFile, program: candidate };
         }
     }
 
@@ -162,6 +153,11 @@ const createOrGetTsModule = (options: TscOptions): TscModule => {
     debug(`created program for module: ${id}`);
 
     context.programs.push(module.program);
+
+    // Bound retention so many-entry builds don't accumulate one program per entry.
+    while (context.programs.length > MAX_RETAINED_PROGRAMS) {
+        context.programs.shift();
+    }
 
     return module;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,7 @@ catalogs:
       version: 3.0.0
 
 overrides:
+  eslint-plugin-sonarjs@<4.1.0: '>=4.2.0'
   '@hono/node-server@<1.19.13': '>=1.19.13'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   axios@>=1.0.0 <1.15.0: '>=1.15.0'
@@ -12138,8 +12139,8 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
 
-  eslint-plugin-sonarjs@4.0.3:
-    resolution: {integrity: sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==}
+  eslint-plugin-sonarjs@4.2.0:
+    resolution: {integrity: sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==}
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
@@ -12695,6 +12696,10 @@ packages:
 
   globals@17.6.0:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+    engines: {node: '>=18'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -18376,7 +18381,7 @@ snapshots:
       eslint-plugin-regexp: 3.1.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-security: 4.0.0
       eslint-plugin-simple-import-sort: 13.0.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
-      eslint-plugin-sonarjs: 4.0.3(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
+      eslint-plugin-sonarjs: 4.2.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-toml: 1.3.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       eslint-plugin-unicorn: 64.0.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
@@ -18446,7 +18451,7 @@ snapshots:
       eslint-plugin-regexp: 3.1.0(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-security: 4.0.0
       eslint-plugin-simple-import-sort: 13.0.0(eslint@10.7.0(jiti@2.7.0))
-      eslint-plugin-sonarjs: 4.0.3(eslint@10.7.0(jiti@2.7.0))
+      eslint-plugin-sonarjs: 4.2.0(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-toml: 1.3.1(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-unicorn: 64.0.0(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))
@@ -18516,7 +18521,7 @@ snapshots:
       eslint-plugin-regexp: 3.1.0(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-security: 4.0.0
       eslint-plugin-simple-import-sort: 13.0.0(eslint@10.7.0(jiti@2.7.0))
-      eslint-plugin-sonarjs: 4.0.3(eslint@10.7.0(jiti@2.7.0))
+      eslint-plugin-sonarjs: 4.2.0(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-toml: 1.3.1(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-unicorn: 64.0.0(eslint@10.7.0(jiti@2.7.0))
       eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))
@@ -18862,14 +18867,14 @@ snapshots:
       '@babel/helper-replace-supers': 8.0.1(@babel/core@8.0.1)
       '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
       '@babel/traverse': 8.0.4
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@babel/helper-create-regexp-features-plugin@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
       '@babel/helper-annotate-as-pure': 8.0.0
       regexpu-core: 6.4.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
@@ -19809,12 +19814,12 @@ snapshots:
   '@commitlint/is-ignored@20.5.0':
     dependencies:
       '@commitlint/types': 20.5.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@commitlint/is-ignored@21.2.0':
     dependencies:
       '@commitlint/types': 21.2.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@commitlint/lint@20.5.3':
     dependencies:
@@ -19985,13 +19990,13 @@ snapshots:
     dependencies:
       '@simple-libs/child-process-utils': 1.0.2
       '@simple-libs/stream-utils': 1.2.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@conventional-changelog/git-client@3.1.0':
     dependencies:
       '@simple-libs/child-process-utils': 2.0.0
       '@simple-libs/stream-utils': 2.0.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@conventional-changelog/template@1.2.1': {}
 
@@ -20930,7 +20935,7 @@ snapshots:
       nopt: 7.2.1
       proc-log: 3.0.0
       read-package-json-fast: 3.0.2
-      semver: 7.8.1
+      semver: 7.8.5
       walk-up-path: 3.0.1
 
   '@npmcli/map-workspaces@3.0.6':
@@ -24867,7 +24872,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -27053,7 +27058,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.9
       meow: 13.2.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   conventional-commit-types@3.0.0: {}
 
@@ -27917,12 +27922,12 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@7.2.0)
-      semver: 7.8.1
+      semver: 7.8.5
 
   eslint-compat-utils@0.5.1(eslint@10.7.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)
-      semver: 7.8.1
+      semver: 7.8.5
 
   eslint-config-flat-gitignore@2.3.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
@@ -28344,37 +28349,39 @@ snapshots:
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)
 
-  eslint-plugin-sonarjs@4.0.3(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-plugin-sonarjs@4.2.0(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       builtin-modules: 3.3.0
       bytes: 3.1.2
       eslint: 10.7.0(jiti@2.7.0)(supports-color@7.2.0)
       functional-red-black-tree: 1.0.1
-      globals: 17.6.0
+      globals: 17.7.0
       jsx-ast-utils-x: 0.1.0
       lodash.merge: 4.6.2
       minimatch: 10.2.5
       scslre: 0.3.0
-      semver: 7.8.1
-      ts-api-utils: 2.5.0(typescript@7.0.2)
-      typescript: 7.0.2
+      semver: 7.8.5
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+      yaml: 2.9.0
 
-  eslint-plugin-sonarjs@4.0.3(eslint@10.7.0(jiti@2.7.0)):
+  eslint-plugin-sonarjs@4.2.0(eslint@10.7.0(jiti@2.7.0)):
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       builtin-modules: 3.3.0
       bytes: 3.1.2
       eslint: 10.7.0(jiti@2.7.0)
       functional-red-black-tree: 1.0.1
-      globals: 17.6.0
+      globals: 17.7.0
       jsx-ast-utils-x: 0.1.0
       lodash.merge: 4.6.2
       minimatch: 10.2.5
       scslre: 0.3.0
-      semver: 7.8.1
-      ts-api-utils: 2.5.0(typescript@7.0.2)
-      typescript: 7.0.2
+      semver: 7.8.5
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+      yaml: 2.9.0
 
   eslint-plugin-toml@1.3.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
@@ -29159,6 +29166,8 @@ snapshots:
   globals@15.15.0: {}
 
   globals@17.6.0: {}
+
+  globals@17.7.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -31673,26 +31682,26 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.2
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@4.0.1:
     dependencies:
       hosted-git-info: 5.2.1
       is-core-module: 2.16.2
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.3
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@9.0.0:
@@ -32240,7 +32249,7 @@ snapshots:
       got: 12.6.1
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   package-manager-detector@1.6.0: {}
 
@@ -34200,7 +34209,7 @@ snapshots:
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   semver-regex@4.0.5: {}
 
@@ -35050,10 +35059,6 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-api-utils@2.5.0(typescript@7.0.2):
-    dependencies:
-      typescript: 7.0.2
-
   ts-declaration-location@1.0.7(typescript@6.0.3):
     dependencies:
       picomatch: 4.0.4
@@ -35670,7 +35675,7 @@ snapshots:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1942,13 +1942,13 @@ importers:
         specifier: catalog:visulima
         version: 3.0.0(@visulima/find-cache-dir@3.0.0)(@visulima/pail@4.0.0(express@5.2.1)(hono@4.12.25))(github-slugger@2.0.0)
       '@visulima/packem-share':
-        specifier: 1.0.0-alpha.50
+        specifier: 1.0.0-alpha.51
         version: link:../packem-share
       '@visulima/rollup-plugin-css':
-        specifier: 1.0.0-alpha.54
+        specifier: 1.0.0-alpha.55
         version: link:../rollup-plugin-css
       '@visulima/rollup-plugin-dts':
-        specifier: 1.0.0-alpha.35
+        specifier: 1.0.0-alpha.36
         version: link:../rollup-plugin-dts
       '@visulima/tsconfig':
         specifier: catalog:visulima
@@ -2126,7 +2126,7 @@ importers:
         specifier: workspace:*
         version: link:../packem-plugins
       '@visulima/packem-rollup':
-        specifier: 1.0.0-alpha.75
+        specifier: 1.0.0-alpha.76
         version: link:../packem-rollup
       '@visulima/pail':
         specifier: catalog:visulima
@@ -2601,13 +2601,13 @@ importers:
         specifier: catalog:visulima
         version: 5.0.0(ini@7.0.0)(jsonc-parser@3.3.1)(smol-toml@1.6.1)
       '@visulima/packem-share':
-        specifier: 1.0.0-alpha.50
+        specifier: 1.0.0-alpha.51
         version: link:../packem-share
       '@visulima/path':
         specifier: catalog:visulima
         version: 3.0.0
       '@visulima/rollup-plugin-dts':
-        specifier: 1.0.0-alpha.35
+        specifier: 1.0.0-alpha.36
         version: link:../rollup-plugin-dts
       clean-css:
         specifier: catalog:style
@@ -2953,7 +2953,7 @@ importers:
         specifier: catalog:visulima
         version: 5.0.0(ini@7.0.0)(jsonc-parser@3.3.1)(smol-toml@1.6.1)
       '@visulima/packem-share':
-        specifier: 1.0.0-alpha.50
+        specifier: 1.0.0-alpha.51
         version: link:../packem-share
       '@visulima/path':
         specifier: catalog:visulima

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -324,6 +324,7 @@ onlyBuiltDependencies:
   - rs-module-lexer
   - unrs-resolver
 overrides:
+  "eslint-plugin-sonarjs@<4.1.0": ">=4.2.0"
   "@hono/node-server@<1.19.13": ">=1.19.13"
   ajv@>=7.0.0-alpha.0 <8.18.0: ">=8.18.0"
   axios@>=1.0.0 <1.15.0: ">=1.15.0"


### PR DESCRIPTION
## What

Fixes the out-of-memory crash on packages with many DTS entries (#216).

The `tsc` DTS path rooted a single program at `[id, ...ALL entries]` and cached it, so the first module built one program spanning **every** entry. With `noEmitOnError`, that program full-type-checked the entire entry set at once, so peak memory scaled with total entry count and OOM'd on many-entry packages (~37+ entries exceeded a 4 GB heap). `dtsConcurrency` could not help, because the one shared program already spanned all roots.

## How

- Root each program at only its own module. TypeScript still follows that module's imports, which is all emitting its declaration needs.
- Reuse any retained program that already contains the module as a source file, recovering cross-entry sharing without rooting at all entries.
- Cap the number of retained programs (`MAX_RETAINED_PROGRAMS`) so independent entries don't re-accumulate unbounded.

## Impact

Measured on a synthetic 60-entry build: peak heap dropped from **~3468 MB to ~1318 MB**, and the growth curve flattened from steep (OOMs at scale) to gentle. A regression test asserts every entry still emits a correct declaration and that program retention stays bounded.

## Notes

Also syncs `pnpm-lock.yaml` with the bumped internal workspace specifiers so `pnpm install --frozen-lockfile` passes (the stale lockfile was failing every CI job before install even completed).

Closes #216
